### PR TITLE
docs(release): finalize v3.19.1-31 notes

### DIFF
--- a/docs/release-notes/v3.19.1-31-zh.md
+++ b/docs/release-notes/v3.19.1-31-zh.md
@@ -9,12 +9,19 @@
 - 显式选择 `web_search`/`image_generation` 时继续使用原有的有界 Hosted Tool loop；客户端原本就是非流式时也保持原行为。
 - 流式判定同时遵循请求体和 HTTP 头，不假设 `stream` 字段一定存在。
 
+## Reasoning 能力修复
+
+- 统一 Codex reasoning 档位的声明、可选档位与上游映射，窄档位 Provider 仍能正确映射 `medium`、`xhigh` 等 Codex 请求。
+- 官方模型目录刷新时保留模型已经声明的 reasoning 能力，避免刷新后推理档位退化或消失。
+- Sub-Agent reasoning 能力解析保持 fail-closed：未知档位不会被静默转发为错误的上游值。
+
 ## 验证
 
 - 新增 RED/GREEN 回归，覆盖流式 auto、显式 Hosted 工具选择和非流式 auto 三条边界。
 - 原有 Hosted Web Search loop 回归通过。
-- Rust library：3000 项通过，0 项失败，2 项忽略。
-- `cargo check --lib`、rustfmt 和 Git whitespace 检查通过。
+- Rust library：3006 项通过，0 项失败，2 项忽略。
+- Reasoning 合流定向测试：3/3 通过；前端相关测试：179/179 通过。
+- TypeScript typecheck、`cargo check --lib`、rustfmt 和 Git whitespace 检查通过。
 
 ## 相关远端修复
 


### PR DESCRIPTION
## Summary\n\nFinalize the v3.19.1-31 release notes after the Qwen streaming branch and cloud reasoning PR were integrated.\n\n- document the merged reasoning capability fixes\n- record the final combined Rust and frontend validation counts\n- keep the release notes aligned with the exact release candidate\n\n## Validation\n\n- UTF-8 strict decode without BOM\n- git diff --check\n- content-only change; underlying candidate validation remains 3006 Rust tests passed, 2 ignored, and 179/179 focused frontend tests passed