### PR TITLE
模型排序

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1291,6 +1291,7 @@ struct CodexCatalogModelSpec {
     input_modalities: Option<Vec<String>>,
     base_instructions: Option<String>,
     reasoning: Option<crate::proxy::providers::codex_reasoning::CodexModelReasoningCapability>,
+    sort_index: Option<u32>,
 }
 
 /// 为 Codex 多 Agent 工具的模型说明生成稳定排序键。
@@ -1361,16 +1362,23 @@ fn sort_codex_catalog_specs_for_picker(
 ) -> Vec<CodexCatalogModelSpec> {
     let mut indexed_specs = specs.into_iter().enumerate().collect::<Vec<_>>();
     indexed_specs.sort_by_key(|(original_index, spec)| {
+        // 优先级1: 用户设置的 sortIndex（数字越小越靠前）
+        if let Some(sort_idx) = spec.sort_index {
+            return (0_u8, sort_idx as usize, *original_index);
+        }
+
+        // 优先级2: spawn_agent_model_priority 列表
         if let Some(priority_index) =
             codex_spawn_agent_model_priority_index(spawn_agent_model_priority, &spec.model)
         {
-            return (0_u8, priority_index, *original_index);
+            return (1_u8, priority_index, *original_index);
         }
 
+        // 优先级3: 默认供应商排序逻辑
         let (provider_rank, fallback_index) =
             codex_catalog_model_priority_key(spec, *original_index);
         (
-            provider_rank.saturating_add(1),
+            provider_rank.saturating_add(2),
             fallback_index,
             *original_index,
         )
@@ -1577,6 +1585,12 @@ fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCa
             })
             .or_else(|| official_reasoning_capability_for_model(model, &official_models));
 
+        let sort_index = model_config
+            .get("sortIndex")
+            .or_else(|| model_config.get("sort_index"))
+            .and_then(|value| value.as_u64())
+            .and_then(|value| u32::try_from(value).ok());
+
         specs.push(CodexCatalogModelSpec {
             model: model.to_string(),
             upstream_model,
@@ -1590,6 +1604,7 @@ fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCa
             input_modalities,
             base_instructions,
             reasoning,
+            sort_index,
         });
     }
 
@@ -6399,6 +6414,7 @@ mod tests {
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }
     }
 
@@ -6625,6 +6641,7 @@ mod tests {
                 input_modalities: None,
                 base_instructions: None,
                 reasoning: None,
+                sort_index: None,
             },
             CodexCatalogModelSpec {
                 model: "model-b".to_string(),
@@ -6637,6 +6654,7 @@ mod tests {
                 input_modalities: None,
                 base_instructions: None,
                 reasoning: None,
+                sort_index: None,
             },
         ];
         sync_codex_managed_agent_files_with_settings(
@@ -8048,6 +8066,7 @@ mod tests {
             input_modalities: None,
             base_instructions: None,
             reasoning: Some(deepseek_reasoning_capability()),
+            sort_index: None,
         }];
 
         sync_codex_managed_agent_files_with_settings(
@@ -8337,6 +8356,7 @@ mod tests {
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         };
         let path = agents_dir.join("stable-role.toml");
 
@@ -8401,6 +8421,7 @@ mod tests {
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
         sync_codex_managed_agent_files_with_settings(
             &specs,
@@ -10109,6 +10130,7 @@ openai_base_url = "http://127.0.0.1:15721/v1"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
         let catalog = codex_model_catalog_from_specs(
             &specs,
@@ -10504,6 +10526,7 @@ openai_base_url = "http://127.0.0.1:15721/v1"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         };
         let entry = codex_catalog_model_entry(
             &template,
@@ -10555,6 +10578,7 @@ openai_base_url = "http://127.0.0.1:15721/v1"
             input_modalities: Some(vec!["text".to_string(), "image".to_string()]),
             base_instructions: Some("base".to_string()),
             reasoning: None,
+            sort_index: None,
         };
 
         let entry = codex_catalog_model_entry(
@@ -10712,6 +10736,36 @@ openai_base_url = "http://127.0.0.1:15721/v1"
     }
 
     #[test]
+    /// 全量模型菜单的用户排序优先于子 Agent 候选和历史默认排序。
+    fn codex_model_catalog_uses_user_model_sort_index_for_picker_order() {
+        let settings = json!({
+            "modelCatalog": {
+                "spawnAgentModels": [
+                    "deepseek-v4-pro",
+                    "qwen3.6"
+                ],
+                "models": [
+                    { "model": "gpt-5.5", "sortIndex": 2 },
+                    { "model": "qwen3.6", "sortIndex": 1 },
+                    { "model": "deepseek-v4-pro", "sort_index": 0 },
+                    { "model": "gpt-5.4" }
+                ]
+            }
+        });
+
+        let ordered = codex_catalog_model_specs(&settings, r#"model = "gpt-5.5""#)
+            .into_iter()
+            .map(|spec| spec.model)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ordered,
+            vec!["deepseek-v4-pro", "qwen3.6", "gpt-5.5", "gpt-5.4"],
+            "sortIndex must control the complete picker order and leave unranked models available"
+        );
+    }
+
+    #[test]
     /// 未声明 reasoning 的第三方模型不能继承 GPT 档位，但仍必须保留
     /// Codex `ModelInfo` 反序列化所需的空 reasoning 数组。缺失该字段会让
     /// `windowsSandbox/setupStart` 在启动 UAC helper 前因 invalid_config 失败。
@@ -10740,6 +10794,7 @@ openai_base_url = "http://127.0.0.1:15721/v1"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         };
         let entry = codex_catalog_model_entry(
             &template,
@@ -11125,6 +11180,7 @@ openai_base_url = "http://127.0.0.1:15721/v1"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
         let config = r#"model_provider = "codex_model_router_v2"
 
@@ -11172,6 +11228,7 @@ base_url = "http://127.0.0.1:15721/v1"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
         let catalog = json!({
             "models": [{
@@ -11255,6 +11312,7 @@ base_url = "http://127.0.0.1:15721/v1"
                     source: Some("builtin".into()),
                 },
             ),
+            sort_index: None,
         }];
         let catalog = codex_model_catalog_from_specs(
             &specs,
@@ -11328,6 +11386,7 @@ base_url = "http://127.0.0.1:15721/v1"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
         let config = r#"model_provider = "codex_model_router_v2"
 
@@ -11763,6 +11822,7 @@ model_context_window = 262144
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
 
         sync_codex_managed_agent_files(&specs, CodexSubagentVersion::V2)
@@ -11870,6 +11930,7 @@ model_provider = "custom"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
 
         sync_codex_managed_agent_files(&specs, CodexSubagentVersion::V2)
@@ -11926,6 +11987,7 @@ model_provider = "custom"
                 input_modalities: None,
                 base_instructions: None,
                 reasoning: None,
+                sort_index: None,
             },
         )
         .collect::<Vec<_>>();
@@ -11985,6 +12047,7 @@ model_provider = "custom"
                 input_modalities: None,
                 base_instructions: None,
                 reasoning: None,
+                sort_index: None,
             },
         )
         .collect::<Vec<_>>();
@@ -12109,6 +12172,7 @@ model = "handwritten"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
 
         sync_codex_managed_agent_files(&specs, CodexSubagentVersion::V2)
@@ -12254,6 +12318,7 @@ model_provider = "codex_model_router_v2"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         };
         let entry = codex_catalog_model_entry(
             &template,
@@ -12308,6 +12373,7 @@ model_provider = "codex_model_router_v2"
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         };
         let entry = codex_catalog_model_entry(
             &template,
@@ -12491,6 +12557,7 @@ max_depth = 2
             input_modalities: None,
             base_instructions: None,
             reasoning: None,
+            sort_index: None,
         }];
         let catalog_path = get_codex_model_catalog_path();
 

--- a/src/components/codex/CodexRouterWorkspacePage.test.ts
+++ b/src/components/codex/CodexRouterWorkspacePage.test.ts
@@ -1763,7 +1763,15 @@ describe("Codex MultiRouter workspace route persistence helpers", () => {
       within(screen.getByRole("tablist"))
         .getAllByRole("tab")
         .map((tab) => tab.textContent?.trim()),
-    ).toEqual(["总览", "模型源", "路由规则", "子 Agent", "状态", "测试发布"]);
+    ).toEqual([
+      "总览",
+      "模型源",
+      "路由规则",
+      "模型排序",
+      "子 Agent",
+      "状态",
+      "测试发布",
+    ]);
     expect(screen.queryByText("Sub-Agent 设置")).not.toBeInTheDocument();
 
     await userEvent
@@ -2721,6 +2729,51 @@ describe("Codex MultiRouter workspace route persistence helpers", () => {
     );
 
     expect(rebuilt.models.map((model) => model.model)).toEqual(["qwen3.6"]);
+  });
+
+  it("preserves the full picker order when routes rebuild the model catalog", () => {
+    const source: Provider = {
+      id: "sorted-source",
+      name: "Sorted Source",
+      category: "custom",
+      settingsConfig: {
+        modelCatalog: {
+          models: [{ model: "model-a" }, { model: "model-b" }],
+        },
+      },
+    };
+    const plan: Provider = {
+      ...createDraftRoutingPlan([source], [source]),
+      settingsConfig: {
+        modelCatalog: {
+          models: [
+            { model: "model-a", sortIndex: 1 },
+            { model: "model-b", sortIndex: 0 },
+          ],
+          spawnAgentModels: ["model-a"],
+        },
+      },
+    };
+
+    const rebuilt = buildModelCatalogForRoutes(
+      plan,
+      [
+        {
+          id: "sorted-route",
+          enabled: true,
+          targetProviderId: source.id,
+          match: { models: ["model-a", "model-b"], prefixes: [] },
+          upstream: { apiFormat: "openai_responses" },
+        },
+      ],
+      new Map([[source.id, source]]),
+    );
+
+    expect(rebuilt.models).toEqual([
+      { model: "model-a", sortIndex: 1 },
+      { model: "model-b", sortIndex: 0 },
+    ]);
+    expect(rebuilt.spawnAgentModels).toEqual(["model-a", "model-b"]);
   });
 
   it("keeps unsaved route picker enabled draft state across candidate refreshes", () => {

--- a/src/components/codex/CodexRouterWorkspacePage.tsx
+++ b/src/components/codex/CodexRouterWorkspacePage.tsx
@@ -140,6 +140,7 @@ export type WorkspaceTab =
   | "overview"
   | "sources"
   | "routes"
+  | "model-order"
   | "subagents"
   | "status"
   | "test";
@@ -462,6 +463,7 @@ type CodexCatalogModelDraft = {
   supportsImage?: boolean;
   supports_image?: boolean;
   vision?: boolean;
+  sortIndex?: number;
   capabilities?: CodexRouteCapabilities;
 };
 
@@ -716,6 +718,7 @@ function providerWithFetchedModelCatalog(
         ? { supports_image: model.supports_image }
         : {}),
       ...(model.vision !== undefined ? { vision: model.vision } : {}),
+      ...(model.sortIndex !== undefined ? { sortIndex: model.sortIndex } : {}),
       // 模型目录刷新必须保留已有 reasoning 声明（用户手动声明的档位/能力）。
       // 否则 /models 拉取重建会把声明清空，导致档位消失（K3/Qwen 均受影响）。
       ...(model.reasoning ? { reasoning: model.reasoning } : {}),
@@ -1307,6 +1310,7 @@ function catalogDraftFromSourceModel(
       ? { supports_image: source.supports_image }
       : {}),
     ...(source?.vision !== undefined ? { vision: source.vision } : {}),
+    ...(source?.sortIndex !== undefined ? { sortIndex: source.sortIndex } : {}),
     ...(capabilities ? { capabilities } : {}),
   };
 }
@@ -1786,8 +1790,12 @@ export function buildModelCatalogForRoutes(
       modelIds.filter((model) => !existingSpawnAgentModels.includes(model)),
     )
     .slice(0, 5);
+  const orderedModels = Array.from(byModel.entries()).map(([id, model]) => {
+    const sortIndex = existingModelById.get(id)?.sortIndex;
+    return sortIndex === undefined ? model : { ...model, sortIndex };
+  });
   return {
-    models: Array.from(byModel.values()),
+    models: orderedModels,
     spawnAgentModels,
   };
 }
@@ -3072,7 +3080,7 @@ export function CodexRouterWorkspacePage({
           onValueChange={(value) => setActiveTab(value as WorkspaceTab)}
         >
           <div className="sticky top-0 z-10 -mx-1 bg-background/95 px-1 py-2 backdrop-blur">
-            <TabsList className="grid w-full grid-cols-3 bg-muted p-1 dark:bg-slate-950/40 lg:grid-cols-6">
+            <TabsList className="grid w-full grid-cols-3 bg-muted p-1 dark:bg-slate-950/40 lg:grid-cols-7">
               <WorkspaceTabTrigger
                 value="overview"
                 icon={Layers3}
@@ -3087,6 +3095,11 @@ export function CodexRouterWorkspacePage({
                 value="routes"
                 icon={Route}
                 label="路由规则"
+              />
+              <WorkspaceTabTrigger
+                value="model-order"
+                icon={GripVertical}
+                label="模型排序"
               />
               <WorkspaceTabTrigger
                 value="subagents"
@@ -3159,6 +3172,13 @@ export function CodexRouterWorkspacePage({
               routePickerMessage={routePickerMessage}
               routePickerError={routePickerError}
               onRoutePickerOpenChange={setIsRoutePickerOpen}
+            />
+          </TabsContent>
+
+          <TabsContent value="model-order" className="mt-3">
+            <ModelOrderTab
+              selectedPlan={selectedPlan}
+              onCreatePlan={handleCreatePlan}
             />
           </TabsContent>
 
@@ -3617,6 +3637,210 @@ function SubagentsTab({
         selectedRoutes={selectedRoutes}
       />
     </div>
+  );
+}
+
+function ModelOrderTab({
+  selectedPlan,
+  onCreatePlan,
+}: {
+  selectedPlan: Provider | null;
+  onCreatePlan: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [draftModels, setDraftModels] = useState<CodexCatalogModel[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+  const catalog = readCodexModelCatalog(selectedPlan);
+  const catalogKey = catalog.models
+    .map((model) => `${model.model ?? ""}:${model.sortIndex ?? ""}`)
+    .join("\n");
+  const hasCustomOrder = catalog.models.some(
+    (model) => model.sortIndex !== undefined,
+  );
+  const hasChanges =
+    draftModels.map((model) => model.model).join("\n") !==
+      catalog.models
+        .slice()
+        .sort(
+          (left, right) =>
+            (left.sortIndex ?? Number.MAX_SAFE_INTEGER) -
+            (right.sortIndex ?? Number.MAX_SAFE_INTEGER),
+        )
+        .map((model) => model.model)
+        .join("\n");
+
+  useEffect(() => {
+    setDraftModels(
+      catalog.models
+        .slice()
+        .sort(
+          (left, right) =>
+            (left.sortIndex ?? Number.MAX_SAFE_INTEGER) -
+            (right.sortIndex ?? Number.MAX_SAFE_INTEGER),
+        ),
+    );
+    setMessage(null);
+    setError(null);
+  }, [selectedPlan?.id, catalogKey]);
+
+  function handleDragEnd(event: DragEndEvent) {
+    const activeModel = String(event.active.id);
+    const overModel = event.over ? String(event.over.id) : "";
+    if (!overModel || activeModel === overModel) return;
+    setDraftModels((current) => {
+      const activeIndex = current.findIndex(
+        (model) => model.model?.trim() === activeModel,
+      );
+      const overIndex = current.findIndex(
+        (model) => model.model?.trim() === overModel,
+      );
+      if (activeIndex < 0 || overIndex < 0) return current;
+      const next = [...current];
+      const [moved] = next.splice(activeIndex, 1);
+      next.splice(overIndex, 0, moved);
+      return next;
+    });
+    setMessage(null);
+    setError(null);
+  }
+
+  async function saveOrder(reset = false) {
+    if (!selectedPlan) return;
+    setIsSaving(true);
+    setMessage(null);
+    setError(null);
+    try {
+      const currentModelCatalog =
+        selectedPlan.settingsConfig?.modelCatalog &&
+        typeof selectedPlan.settingsConfig.modelCatalog === "object"
+          ? selectedPlan.settingsConfig.modelCatalog
+          : {};
+      const models = (reset ? catalog.models : draftModels).map(
+        (model, index) => {
+          const rest = { ...model };
+          delete rest.sortIndex;
+          return reset ? rest : { ...rest, sortIndex: index };
+        },
+      );
+      const nextProvider: Provider = {
+        ...selectedPlan,
+        settingsConfig: {
+          ...selectedPlan.settingsConfig,
+          modelCatalog: {
+            ...currentModelCatalog,
+            models,
+          },
+        },
+      };
+      await providersApi.update(nextProvider, "codex");
+      setDraftModels(models);
+      setMessage(
+        reset
+          ? "已恢复默认模型顺序；重启 Codex Desktop 后生效。"
+          : `已保存 ${models.length} 个模型的展示顺序；重启 Codex Desktop 后生效。`,
+      );
+      await queryClient.invalidateQueries({ queryKey: ["providers", "codex"] });
+    } catch (saveError) {
+      setError(`保存模型顺序失败：${workspaceErrorMessage(saveError)}`);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (!selectedPlan) {
+    return (
+      <EmptyState
+        icon={GripVertical}
+        title="还没有可排序的 MultiRouter"
+        detail="先创建或选择一个多路路由方案，再调整 Codex 模型选择器中的全量模型顺序。"
+        actionLabel="创建多路路由"
+        onAction={onCreatePlan}
+      />
+    );
+  }
+
+  if (catalog.models.length === 0) {
+    return (
+      <EmptyState
+        icon={GripVertical}
+        title="当前方案没有模型目录"
+        detail="先在“路由规则”中接入模型源并保存，模型目录生成后即可在这里排序。"
+        actionLabel="前往路由规则"
+      />
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-blue-200 bg-blue-50/50 p-4 dark:border-blue-700/40 dark:bg-blue-950/10">
+      <SectionHeader
+        icon={GripVertical}
+        title="Codex 模型排序"
+        detail="拖动调整所有自定义模型在 Codex 模型选择器中的顺序。子 Agent 候选、路由规则和默认模型不会因此改变。"
+        action={
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={isSaving || !hasCustomOrder}
+              onClick={() => void saveOrder(true)}
+            >
+              恢复默认
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={isSaving || !hasChanges}
+              onClick={() => void saveOrder()}
+              className="gap-2 bg-blue-600 hover:bg-blue-500"
+            >
+              <Save className="h-4 w-4" />
+              保存顺序
+            </Button>
+          </div>
+        }
+      />
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={draftModels
+            .map((model) => model.model?.trim())
+            .filter((model): model is string => Boolean(model))}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="mt-4 space-y-2">
+            {draftModels.map((model, index) => (
+              <SortableCatalogModel
+                key={model.model}
+                model={model}
+                index={index}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+
+      {message ? (
+        <p className="mt-3 text-xs text-emerald-700 dark:text-emerald-200">
+          {message}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="mt-3 text-xs text-rose-700 dark:text-rose-200">{error}</p>
+      ) : null}
+    </section>
   );
 }
 
@@ -7359,6 +7583,64 @@ function SortableSpawnAgentCandidate({
       >
         <Trash2 className="h-4 w-4" />
       </Button>
+    </div>
+  );
+}
+
+function SortableCatalogModel({
+  model,
+  index,
+}: {
+  model: CodexCatalogModel;
+  index: number;
+}) {
+  const modelId = model.model?.trim() ?? "";
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: modelId });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      className={cn(
+        "flex min-h-11 items-center gap-3 rounded-md border border-blue-200 bg-background px-3 py-2 dark:border-blue-800/60 dark:bg-slate-950/50",
+        isDragging ? "opacity-60 shadow-lg shadow-blue-950/30" : "",
+      )}
+    >
+      <button
+        type="button"
+        className="grid h-7 w-7 shrink-0 place-items-center rounded border border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-700/60 dark:bg-blue-500/10 dark:text-blue-200 dark:hover:bg-blue-500/20"
+        {...attributes}
+        {...listeners}
+        aria-label={`拖动 ${modelId}`}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <span className="w-7 shrink-0 text-right font-mono text-xs text-muted-foreground dark:text-slate-400">
+        {index + 1}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div
+          className="truncate text-sm font-medium text-foreground dark:text-slate-100"
+          title={catalogModelLabel(model)}
+        >
+          {catalogModelLabel(model)}
+        </div>
+        {model.upstreamModel || model.upstream_model ? (
+          <div className="mt-0.5 truncate font-mono text-xs text-muted-foreground dark:text-slate-400">
+            {model.upstreamModel ?? model.upstream_model}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/lib/codexMultiRouterSync.ts
+++ b/src/lib/codexMultiRouterSync.ts
@@ -335,7 +335,12 @@ function rebuildPlanModelCatalog(
     }
   }
 
-  const models = Array.from(byModel.values());
+  // 路由同步会重建模型元数据，但全量菜单排序属于 MultiRouter 自身的用户偏好，
+  // 不能因模型源刷新或规则保存而被覆盖。
+  const models = Array.from(byModel.entries()).map(([id, model]) => {
+    const sortIndex = planCatalogByModel.get(id)?.sortIndex;
+    return sortIndex === undefined ? model : { ...model, sortIndex };
+  });
   const existingSpawnAgentModels = Array.isArray(
     plan.settingsConfig?.modelCatalog?.spawnAgentModels,
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -334,6 +334,8 @@ export interface CodexCatalogModel {
   baseInstructions?: string;
   base_instructions?: string;
   reasoning?: CodexModelReasoningCapability;
+  // User-defined picker order. Lower values appear first in Codex.
+  sortIndex?: number;
 }
 
 export type CodexCacheMode =


### PR DESCRIPTION
## Summary / 概述

本次 PR 主要是针对 Codex 多模型路由进行模型排序，使 Codex 中的自定义模型按照指定顺序展示

## Related Issue / 关联 Issue



Fixes #

## Screenshots / 截图
旧版 ccsm
<img width="1220" height="780" alt="image" src="https://github.com/user-attachments/assets/aaf26881-a988-4015-af4f-ebfe42e69cde" />

pr 新增顶部模型排序 tab，拖动即可进行模型排序
<img width="1220" height="781" alt="image" src="https://github.com/user-attachments/assets/44258153-dbfc-4934-813f-9839000601ef" />



## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
