### PR TITLE
fix(codex): classify v2 authPolicy routes as native/desktop auth (closes #36)

### DIFF
--- a/src-tauri/src/codex_multirouter/migration.rs
+++ b/src-tauri/src/codex_multirouter/migration.rs
@@ -6,6 +6,7 @@ use super::schema::{
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
+use crate::proxy::providers::codex_route_auth_source;
 use rusqlite::params;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -701,7 +702,7 @@ fn apply_model_capabilities(
 }
 
 fn infer_official_target(route: &Value) -> Option<String> {
-    let source = route.pointer("/upstream/auth/source")?.as_str()?;
+    let source = codex_route_auth_source(route)?;
     matches!(
         source,
         "managed_codex_oauth" | "native_codex_auth" | "account_pool"

--- a/src-tauri/src/proxy/external_openai_api.rs
+++ b/src-tauri/src/proxy/external_openai_api.rs
@@ -8,6 +8,7 @@ use crate::app_config::AppType;
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
+use crate::proxy::providers::codex_route_auth_source;
 use crate::proxy::providers::{CodexAdapter, ProviderAdapter};
 use axum::http::HeaderMap;
 use indexmap::IndexMap;
@@ -924,9 +925,7 @@ fn collect_model_array(ids: &mut BTreeSet<String>, value: Option<&Value>) {
 /// 判断 router route 是否交给 CC Switch 管理的 OAuth/账号认证。
 fn route_uses_managed_oauth(route: &Value) -> bool {
     matches!(
-        route
-            .pointer("/upstream/auth/source")
-            .and_then(|value| value.as_str()),
+        codex_route_auth_source(route),
         Some("managed_codex_oauth" | "managed_account")
     )
 }

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -51,6 +51,23 @@ pub enum CodexMultiRouterAuthFacade {
     LegacyPreserved,
 }
 
+/// 统一提取 route 的 auth source，兼容新旧两种 schema。
+///
+/// v1 route 把认证声明放在 `upstream.auth.source`；v2 route（schema v2 迁移后）
+/// 顶层 `authPolicy.source` 是唯一声明位（保存时不再写 upstream）。其余函数
+/// （如 [`codex_route_uses_official_agent_backend`]）已支持多字段兜底，这里
+/// 收敛到同一提取逻辑，避免 `authPolicy` 缺失导致认证门面误判。
+pub(crate) fn codex_route_auth_source(route: &JsonValue) -> Option<&str> {
+    let upstream = route.get("upstream").unwrap_or(route);
+    let auth = upstream
+        .get("auth")
+        .or_else(|| route.get("auth"))
+        .or_else(|| route.get("authPolicy"))
+        .or_else(|| route.get("auth_policy"))
+        .unwrap_or(upstream);
+    auth.get("source").and_then(JsonValue::as_str)
+}
+
 /// 根据持久化 Router 配置和账号池策略判断本地认证门面。
 ///
 /// route 是运行时认证所有权的最终事实；`officialAuth` 由保存流程物化到 route，
@@ -86,9 +103,7 @@ pub fn classify_codex_multirouter_auth_facade(
             continue;
         }
         has_enabled_route = true;
-        let source = route
-            .pointer("/upstream/auth/source")
-            .and_then(JsonValue::as_str);
+        let source = codex_route_auth_source(route);
         match source {
             Some("native_codex_auth") => needs_native_auth = true,
             Some("account_pool") => match pool_policy {
@@ -123,19 +138,16 @@ pub(crate) fn codex_route_uses_official_agent_backend(route: &JsonValue) -> bool
         .or_else(|| route.get("authPolicy"))
         .or_else(|| route.get("auth_policy"))
         .unwrap_or(upstream);
-    auth.get("source")
+    codex_route_auth_source(route).is_some_and(|source| {
+        matches!(
+            source.to_ascii_lowercase().as_str(),
+            "native_codex_auth" | "managed_codex_oauth" | "managed_account" | "account_pool"
+        )
+    }) || auth
+        .get("authProvider")
+        .or_else(|| auth.get("auth_provider"))
         .and_then(JsonValue::as_str)
-        .is_some_and(|source| {
-            matches!(
-                source.to_ascii_lowercase().as_str(),
-                "native_codex_auth" | "managed_codex_oauth" | "managed_account" | "account_pool"
-            )
-        })
-        || auth
-            .get("authProvider")
-            .or_else(|| auth.get("auth_provider"))
-            .and_then(JsonValue::as_str)
-            .is_some_and(|provider| provider.eq_ignore_ascii_case("codex_oauth"))
+        .is_some_and(|provider| provider.eq_ignore_ascii_case("codex_oauth"))
 }
 
 /// 官方 Codex 客户端 User-Agent 正则
@@ -3596,6 +3608,113 @@ context_window = 500000
         );
         assert_eq!(
             classify_codex_multirouter_auth_facade(&provider_config, None),
+            CodexMultiRouterAuthFacade::FullyManaged
+        );
+    }
+
+    #[test]
+    fn codex_route_auth_source_reads_all_schema_variants() {
+        // v1：upstream.auth.source
+        assert_eq!(
+            codex_route_auth_source(&json!({
+                "id": "r1",
+                "upstream": { "auth": { "source": "native_codex_auth" } }
+            })),
+            Some("native_codex_auth")
+        );
+        // v2：顶层 authPolicy.source（本次 bug 关键形态）
+        assert_eq!(
+            codex_route_auth_source(&json!({
+                "id": "r2",
+                "authPolicy": { "source": "provider_config" }
+            })),
+            Some("provider_config")
+        );
+        // v2 变体：顶层 auth.source
+        assert_eq!(
+            codex_route_auth_source(&json!({
+                "id": "r3",
+                "auth": { "source": "managed_codex_oauth", "accountId": "a1" }
+            })),
+            Some("managed_codex_oauth")
+        );
+        // 兼容变体：顶层 auth_policy.source
+        assert_eq!(
+            codex_route_auth_source(&json!({
+                "id": "r4",
+                "auth_policy": { "source": "account_pool" }
+            })),
+            Some("account_pool")
+        );
+        // 无任何 auth 声明 → None（保留 ambiguous 判定路径）
+        assert_eq!(
+            codex_route_auth_source(&json!({ "id": "r5", "upstream": { "apiFormat": "openai_responses" } })),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_multirouter_auth_facade_reads_v2_auth_policy_source() {
+        // 回归（母仓库 cd1e7c4b v2 schema 迁移遗漏）：v2 route 的认证声明
+        // 在顶层 authPolicy（保存时不再写 upstream.auth）。若 classify 只读
+        // /upstream/auth/source，官方 route 会漏判 native → 门面降级
+        // FullyManaged → live config 注入 PROXY_MANAGED → 官方 route 401。
+        let native = multirouter_with_routes(
+            json!([{
+                "id": "router-codex-official",
+                "enabled": true,
+                "targetProviderId": "codex-official",
+                "authPolicy": { "source": "native_codex_auth" }
+            }]),
+            Some(json!({ "mode": "desktop_current_login" })),
+        );
+        assert_eq!(
+            classify_codex_multirouter_auth_facade(&native, None),
+            CodexMultiRouterAuthFacade::NativeMixed
+        );
+
+        // v2 顶层 auth 字段同样兼容
+        let native_top_auth = multirouter_with_routes(
+            json!([{
+                "id": "router-codex-official",
+                "enabled": true,
+                "targetProviderId": "codex-official",
+                "auth": { "source": "native_codex_auth" }
+            }]),
+            Some(json!({ "mode": "desktop_current_login" })),
+        );
+        assert_eq!(
+            classify_codex_multirouter_auth_facade(&native_top_auth, None),
+            CodexMultiRouterAuthFacade::NativeMixed
+        );
+
+        // v2 authPolicy 第三方 provider_config 仍判 FullyManaged
+        let provider_config = multirouter_with_routes(
+            json!([{
+                "id": "router-kimi",
+                "enabled": true,
+                "targetProviderId": "kimi",
+                "authPolicy": { "source": "provider_config" }
+            }]),
+            None,
+        );
+        assert_eq!(
+            classify_codex_multirouter_auth_facade(&provider_config, None),
+            CodexMultiRouterAuthFacade::FullyManaged
+        );
+
+        // v2 authPolicy managed_codex_oauth 仍判 FullyManaged
+        let managed = multirouter_with_routes(
+            json!([{
+                "id": "router-official",
+                "enabled": true,
+                "targetProviderId": "codex-official",
+                "authPolicy": { "source": "managed_codex_oauth", "accountId": "managed-account" }
+            }]),
+            Some(json!({ "mode": "managed_oauth", "accountId": "managed-account" })),
+        );
+        assert_eq!(
+            classify_codex_multirouter_auth_facade(&managed, None),
             CodexMultiRouterAuthFacade::FullyManaged
         );
     }

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -79,9 +79,10 @@ pub use codex::{
     CodexMultiRouterAuthFacade, ResolvedCodexRoute,
 };
 pub(crate) use codex::{
-    codex_provider_remote_compaction_enabled, codex_route_supports_responses_compaction,
-    codex_route_target_provider_id_from_route, codex_route_uses_official_agent_backend,
-    is_codex_remote_compact_endpoint, is_codex_responses_endpoint, provider_uses_native_codex_auth,
+    codex_provider_remote_compaction_enabled, codex_route_auth_source,
+    codex_route_supports_responses_compaction, codex_route_target_provider_id_from_route,
+    codex_route_uses_official_agent_backend, is_codex_remote_compact_endpoint,
+    is_codex_responses_endpoint, provider_uses_native_codex_auth,
     resolve_codex_primary_route_from_settings, CODEX_ACCOUNT_POOL_ENABLED,
 };
 pub use gemini::GeminiAdapter;

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -7,6 +7,7 @@ use crate::codex_guardian::{self, GuardianHandle};
 use crate::config::{get_claude_settings_path, read_json_file, write_json_file};
 use crate::database::Database;
 use crate::provider::Provider;
+use crate::proxy::providers::codex_route_auth_source;
 use crate::proxy::switch_lock::SwitchLockManager;
 use crate::proxy::types::*;
 use crate::proxy::{external_openai_api, server::ProxyServer};
@@ -3586,10 +3587,7 @@ impl ProxyService {
                         .get("enabled")
                         .and_then(Value::as_bool)
                         .is_none_or(|enabled| enabled)
-                        && route
-                            .pointer("/upstream/auth/source")
-                            .and_then(Value::as_str)
-                            == Some("account_pool")
+                        && codex_route_auth_source(route) == Some("account_pool")
                 })
             })
     }


### PR DESCRIPTION
Closes #36
Fixes #33

## 概述

修复 Issue #36 描述的 v2 schema 迁移遗漏：官方 route 认证判定漂移导致 401 自锁（`认证失败: 已切换到 OpenAI 官方供应商`，即 #33/#32 报告的报错）。

**根因**：`cd1e7c4b`（v3.19.2-10）把 route 认证声明从 v1 的 `upstream.auth.source` 迁移到顶层 `authPolicy.source`。同批迁移中 `codex_route_uses_official_agent_backend` 同步加了 `authPolicy` 兜底，**唯独 `classify_codex_multirouter_auth_facade` 漏改**，仍只读 `/upstream/auth/source`。v2 route 保存时根本不写 `upstream`（实测 DB：v2 route 只有顶层 `authPolicy`），因此 classify 永远读不到 auth source：

1. 门面判定漂移 NativeMixed → FullyManaged
2. CCSM 重写 live config 时向 `~/.codex/config.toml` 注入 `experimental_bearer_token = "PROXY_MANAGED"` 占位 token
3. Codex 客户端每个请求带 `Bearer PROXY_MANAGED` → 官方 route（native_codex_auth）校验拦截 → 401
4. 一旦写成 FullyManaged 形态即自锁，重启 Codex 无法恢复

**影响面**：全仓库 grep `/upstream/auth/source` 共 4 处运行时逻辑读取 route auth source，仅 1 处支持 authPolicy，其余 3 处（classify / `route_uses_managed_oauth` / `codex_provider_uses_account_pool` / `infer_official_target`）在 v2 schema 下全部失配。

## 改动

- 新增 `pub(crate) fn codex_route_auth_source`（codex.rs），按 `upstream.auth.source → auth.source → authPolicy.source → auth_policy.source` 兜底提取，与仓库内已正确的 `codex_route_uses_official_agent_backend` 对齐
- 替换全部 4 处读 route auth source 的运行时逻辑（classify / `route_uses_managed_oauth` / `codex_provider_uses_account_pool` / `infer_official_target`），经 `providers/mod.rs` re-export
- 补 v1/v2 各形态单元测试 + classify v2 回归测试（6 用例全绿）

**本 PR 仅含上述 1 个 commit**（`574e5ee6`，5 文件 +144/-26），独立于 #35 便于单独审查。若 #35 先行合并（其中包含同一修复），本 PR 自动变为 superseded。

## 测试

- `cargo test --lib`（auth 相关）：6 passed（新增 v2 authPolicy → NativeMixed 回归 + v1 不回归 + managed/account_pool 各形态 + 统一提取函数全形态）
- `cargo check`：零警告
