### PR TITLE
fix(codex): guard missing modelSelection in route read paths (closes #38)

### DIFF
--- a/src/components/codex/CodexMultiRouterWizard.tsx
+++ b/src/components/codex/CodexMultiRouterWizard.tsx
@@ -2305,9 +2305,9 @@ export function CodexMultiRouterWizard({
                     </div>
                     <div className="mt-2 text-sm text-muted-foreground">
                       模型范围：
-                      {route.modelSelection.mode === "all"
+                      {route.modelSelection?.mode === "all"
                         ? "目标 Provider 的全部模型"
-                        : `${route.modelSelection.models.length} 个 canonical 模型`}
+                        : `${(route.modelSelection?.models ?? []).length} 个 canonical 模型`}
                       ；前缀 {(route.matchPrefixes ?? []).join(", ") || "无"}
                     </div>
                     <div className="mt-2 text-xs leading-5 text-muted-foreground">

--- a/src/components/codex/CodexRouterWorkspacePage.test.ts
+++ b/src/components/codex/CodexRouterWorkspacePage.test.ts
@@ -2717,6 +2717,37 @@ describe("Codex MultiRouter workspace route persistence helpers", () => {
     expect(routing?.routes?.[1].match?.prefixes).toEqual(["deepseek-"]);
   });
 
+  it("does not crash when a schema v2 route is missing modelSelection (legacy/synced data)", () => {
+    const plan: Provider = {
+      id: "codex-multirouter",
+      name: "Legacy V2 Router",
+      category: "custom",
+      settingsConfig: {
+        codexRouting: {
+          schemaVersion: 2,
+          enabled: true,
+          routes: [
+            {
+              id: "router-kimi",
+              enabled: true,
+              targetProviderId: "kimi",
+              // modelSelection intentionally missing (pre-schema-v2 / cross-device sync data)
+              matchPrefixes: ["k3"],
+            },
+          ],
+        },
+      },
+    };
+
+    const routing = readCodexRouting(plan);
+
+    expect(routing?.enabled).toBe(true);
+    expect(routing?.routes).toHaveLength(1);
+    expect(routing?.routes?.[0].modelSelection).toEqual({ mode: "all" });
+    expect(routing?.routes?.[0].match?.models).toEqual([]);
+    expect(routing?.routes?.[0].match?.prefixes).toEqual(["k3"]);
+  });
+
   it("keeps legacy provider references and dedupes equivalent route candidates", () => {
     const deepseek: Provider = {
       id: "deepseek",

--- a/src/components/codex/CodexRouterWorkspacePage.tsx
+++ b/src/components/codex/CodexRouterWorkspacePage.tsx
@@ -1076,22 +1076,25 @@ export function readCodexRouting(
       subagentVersion: normalizeCodexSubagentVersion(v2.subagentVersion),
       subagentV2: v2.subagentV2,
       spawnAgentModels: v2.spawnAgentModels ?? [],
-      routes: v2.routes.map((route) => ({
-        ...route,
+      routes: v2.routes.map((route) => {
         // 旧数据/跨设备同步可能缺失 modelSelection（schema v2 之前未强制），补默认值防止 undefined.mode 崩溃
-        modelSelection: route.modelSelection ?? { mode: "all" },
-        match: {
-          models:
-            route.modelSelection.mode === "include"
-              ? route.modelSelection.models
-              : [],
-          prefixes: route.matchPrefixes ?? [],
-        },
-        upstream: {
-          auth: route.authPolicy,
-          modelMap: route.aliases,
-        },
-      })),
+        const modelSelection = route.modelSelection ?? { mode: "all" };
+        return {
+          ...route,
+          modelSelection,
+          match: {
+            models:
+              modelSelection.mode === "include"
+                ? modelSelection.models
+                : [],
+            prefixes: route.matchPrefixes ?? [],
+          },
+          upstream: {
+            auth: route.authPolicy,
+            modelMap: route.aliases,
+          },
+        };
+      }),
     };
   }
   return {

--- a/src/components/codex/CodexRouterWorkspacePage.tsx
+++ b/src/components/codex/CodexRouterWorkspacePage.tsx
@@ -1078,6 +1078,8 @@ export function readCodexRouting(
       spawnAgentModels: v2.spawnAgentModels ?? [],
       routes: v2.routes.map((route) => ({
         ...route,
+        // 旧数据/跨设备同步可能缺失 modelSelection（schema v2 之前未强制），补默认值防止 undefined.mode 崩溃
+        modelSelection: route.modelSelection ?? { mode: "all" },
         match: {
           models:
             route.modelSelection.mode === "include"

--- a/src/lib/codexMultiRouterWizard.ts
+++ b/src/lib/codexMultiRouterWizard.ts
@@ -972,10 +972,10 @@ export function collectWizardRouteAliasSelectionIssues(
       canonicalIds.map((model) => model.toLowerCase()),
     );
     const selectedSet =
-      route.modelSelection.mode === "all"
+      route.modelSelection?.mode === "all"
         ? canonicalSet
         : new Set(
-            route.modelSelection.models.map((model) =>
+            (route.modelSelection?.models ?? []).map((model) =>
               model.trim().toLowerCase(),
             ),
           );


### PR DESCRIPTION
Closes #38

## 概述

修复 Issue #38：schema-v2 route 缺 `modelSelection` 字段（旧数据/跨设备同步合并）时前端直接崩溃白屏（`undefined is not an object (evaluating 'n.modelSelection.mode')`），应用初始化加载失败。

**根因**：`readCodexRouting` 的 v2 分支先补了默认值 `{mode:"all"}` 却仍引用 `route.modelSelection.mode`——补丁与引用对象不一致，等于没保护；CodexMultiRouterWizard 预览与 alias 检查同样对 `modelSelection` 缺 `?.` 守卫。`modelSelection` 是 v3.19.2-10+ 新增字段，旧数据/同步配置缺失属正常情况，前端必须以缺省值容忍。

## 改动（2 个 commit，均基于 v3.19.2-16）

- `eea8182e`：CodexMultiRouterWizard 预览 + alias-issue 检查补 `?.` 缺省守卫；`readCodexRouting` v2 分支默认值修正
- `d35d1d3a`：`readCodexRouting` 统一先提取 `const modelSelection = route.modelSelection ?? {mode:"all"}` 再引用，补 legacy/synced 数据回归测试（CodexRouterWorkspacePage.test.ts）

涉及 4 个前端文件（CodexRouterWorkspacePage.tsx/.test.ts、CodexMultiRouterWizard.tsx、codexMultiRouterWizard.ts），无后端改动。

## 测试

- 前端 `vitest run`：新增 legacy/synced 数据（缺 modelSelection）用例全绿
- `tsc --noEmit`：零错误
