### PR TITLE
fix(codex): restore sortIndex-sorted live catalog on SSOT restore/takeover (closes #40)

### DIFF
--- a/src-tauri/src/codex_multirouter/projection.rs
+++ b/src-tauri/src/codex_multirouter/projection.rs
@@ -206,7 +206,7 @@ fn projection_setting_key(router_provider_id: &str) -> String {
     format!("{PROJECTION_SETTING_PREFIX}{router_provider_id}")
 }
 
-fn build_projection_artifact(
+pub(crate) fn build_projection_artifact(
     db: &Database,
     router_provider_id: &str,
 ) -> Result<CodexRoutingProjectionArtifact, AppError> {

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -779,6 +779,31 @@ pub(crate) fn write_live_with_common_config(
 
     if matches!(app_type, AppType::Codex) {
         let provider_context = crate::codex_config::codex_provider_classification_context(db)?;
+        // MultiRouter schema-v2 router 的 live 写入必须使用投影 settings（含 sortIndex
+        // 排序 + dependency fingerprint），而不是 router 的原始 settings_config：
+        // catalog 生成链（codex_catalog_model_specs → sort_codex_catalog_specs_for_picker）
+        // 依赖 modelCatalog 条目里的 sortIndex 决定展示顺序；router 原始 settings 的
+        // modelCatalog 是旧投影快照（无 sortIndex），会让 Codex 模型菜单按默认供应商
+        // 排序乱序展示。SSOT 恢复/启动接管等路径都经此写 live。
+        let is_v2_router = crate::codex_multirouter::schema::CodexRoutingDocument::parse(
+            effective_provider.settings_config.get("codexRouting").unwrap_or(&serde_json::Value::Null),
+        )
+        .map(|document| {
+            matches!(
+                document,
+                crate::codex_multirouter::schema::CodexRoutingDocument::V2(_)
+            )
+        })
+        .unwrap_or(false);
+        if is_v2_router {
+            let artifact = crate::codex_multirouter::projection::build_projection_artifact(
+                db,
+                &effective_provider.id,
+            )?;
+            let mut projected_provider = effective_provider.clone();
+            projected_provider.settings_config = artifact.projection_settings.clone();
+            return write_codex_live_snapshot(&projected_provider, Some(&provider_context));
+        }
         return write_codex_live_snapshot(&effective_provider, Some(&provider_context));
     }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2064,14 +2064,20 @@ impl ProxyService {
                             self.codex_respect_system_proxy_enabled(),
                         )?;
                     live_config["config"] = json!(updated_config);
+                    // 投影版 provider：sync_codex_model_catalog_projection_flag 会把
+                    // modelCatalog 塞进 live_config，后续 codex_settings_for_model_catalog_projection
+                    // 见 root 已有 modelCatalog 就不再替换——因此这里必须用含 sortIndex 排序的
+                    // 投影 modelCatalog，否则 Codex 模型菜单乱序。
+                    let projected_provider =
+                        self.codex_provider_with_projected_model_catalog(codex_provider.as_ref());
                     Self::sync_codex_model_catalog_projection_flag(
                         &mut live_config,
-                        codex_provider.as_ref(),
+                        projected_provider.as_ref(),
                     );
 
                     self.write_codex_takeover_live_for_provider(
                         &live_config,
-                        codex_provider.as_ref(),
+                        projected_provider.as_ref(),
                     )?;
                 }
             }
@@ -3020,8 +3026,15 @@ impl ProxyService {
                 let provider_context =
                     crate::codex_config::codex_provider_classification_context(self.db.as_ref())
                         .map_err(|e| format!("读取 Codex Provider 分类上下文失败: {e}"))?;
+                // schema-v2 router 必须用投影 settings（含 sortIndex 排序），否则
+                // catalog 生成链读不到 sortIndex → Codex 模型菜单乱序。
+                let settings_for_live =
+                    match self.codex_provider_with_projected_model_catalog(Some(&provider)) {
+                        Some(projected) => projected.settings_config,
+                        None => effective_settings.clone(),
+                    };
                 crate::codex_config::write_codex_provider_live_with_catalog_and_provider_context(
-                    &effective_settings,
+                    &settings_for_live,
                     provider.category.as_deref(),
                     auth,
                     config_str,
@@ -3833,6 +3846,17 @@ impl ProxyService {
         // 与 write_live_with_common_config 的 SSOT 恢复路径保持一致。
         let provider = self.codex_provider_with_projected_model_catalog(provider);
         let provider_ref = provider.as_ref();
+        // 调用方可能已用 sync_codex_model_catalog_projection_flag 往 live_config 塞过
+        // 原始 modelCatalog（无 sortIndex）；codex_settings_for_model_catalog_projection
+        // 见 root 已有 modelCatalog 就不再替换。因此这里强制用投影/当前 modelCatalog 覆盖，
+        // 保证任何 takeover 调用点（启动接管/热切换/回滚）都写出排序正确的 catalog。
+        let mut live_config = config.clone();
+        if let (Some(provider), Some(root)) = (provider_ref, live_config.as_object_mut()) {
+            if let Some(model_catalog) = provider.settings_config.get("modelCatalog").cloned() {
+                root.insert("modelCatalog".to_string(), model_catalog);
+            }
+        }
+        let config = &live_config;
         // 接管态的 `PROXY_MANAGED` 只是本地代理门面 token，不能写入 auth.json。
         // 否则 Codex Desktop 会失去原始 ChatGPT OAuth 登录材料，表现为切换
         // MultiRouter/本地代理后要求重新登录。这里不再依赖兼容设置开关：只要是

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3826,6 +3826,13 @@ impl ProxyService {
         config: &Value,
         provider: Option<&Provider>,
     ) -> Result<(), String> {
+        // MultiRouter schema-v2 router 的 live 写入必须使用投影 modelCatalog（含
+        // sortIndex 排序 + fingerprint），否则 catalog 生成链（codex_catalog_model_specs
+        // → sort_codex_catalog_specs_for_picker）读不到 sortIndex → Codex 模型菜单
+        // 按默认供应商排序乱序。这里是启动接管/热切换等 takeover 写 live 的统一出口，
+        // 与 write_live_with_common_config 的 SSOT 恢复路径保持一致。
+        let provider = self.codex_provider_with_projected_model_catalog(provider);
+        let provider_ref = provider.as_ref();
         // 接管态的 `PROXY_MANAGED` 只是本地代理门面 token，不能写入 auth.json。
         // 否则 Codex Desktop 会失去原始 ChatGPT OAuth 登录材料，表现为切换
         // MultiRouter/本地代理后要求重新登录。这里不再依赖兼容设置开关：只要是
@@ -3836,13 +3843,13 @@ impl ProxyService {
             .is_some()
         {
             let config_for_projection =
-                Self::codex_settings_for_model_catalog_projection(config, provider);
+                Self::codex_settings_for_model_catalog_projection(config, provider_ref);
             let config_str = config_for_projection
                 .get("config")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             let profile = crate::codex_config::CodexCatalogToolProfile::from_api_format(
-                provider.and_then(|p| p.meta.as_ref()?.api_format.as_deref()),
+                provider_ref.and_then(|p| p.meta.as_ref()?.api_format.as_deref()),
             );
             let provider_context =
                 crate::codex_config::codex_provider_classification_context(self.db.as_ref())
@@ -3860,7 +3867,47 @@ impl ProxyService {
             return Ok(());
         }
 
-        self.write_codex_live_for_provider(config, provider)
+        self.write_codex_live_for_provider(config, provider_ref)
+    }
+
+    /// 若 provider 是 schema-v2 MultiRouter，把其 settings_config 的 modelCatalog
+    /// 替换为投影产物（含 sortIndex 排序 + fingerprint）。构建失败时降级用原始配置。
+    fn codex_provider_with_projected_model_catalog(
+        &self,
+        provider: Option<&Provider>,
+    ) -> Option<Provider> {
+        let provider = provider?;
+        let is_v2_router = crate::codex_multirouter::schema::CodexRoutingDocument::parse(
+            provider
+                .settings_config
+                .get("codexRouting")
+                .unwrap_or(&serde_json::Value::Null),
+        )
+        .map(|document| {
+            matches!(
+                document,
+                crate::codex_multirouter::schema::CodexRoutingDocument::V2(_)
+            )
+        })
+        .unwrap_or(false);
+        if !is_v2_router {
+            return Some(provider.clone());
+        }
+        match crate::codex_multirouter::projection::build_projection_artifact(
+            &self.db,
+            &provider.id,
+        ) {
+            Ok(artifact) => {
+                let mut projected = provider.clone();
+                if let Some(model_catalog) =
+                    artifact.projection_settings.get("modelCatalog").cloned()
+                {
+                    projected.settings_config["modelCatalog"] = model_catalog;
+                }
+                Some(projected)
+            }
+            Err(_) => Some(provider.clone()),
+        }
     }
 
     /// 根据 provider meta 决定 `modelCatalog` 是否参与 live 投射；目录元数据仍保存在 DB。

--- a/src/components/codex/CodexRouterWorkspacePage.tsx
+++ b/src/components/codex/CodexRouterWorkspacePage.tsx
@@ -2805,6 +2805,7 @@ export function CodexRouterWorkspacePage({
   // 不能因缺少 targetProviderId 退回到刷新全部候选 Provider。
   const selectedPlanForModelRefresh =
     routingPlans.find((provider) => provider.id === selectedPlanId) ??
+    routingPlans.find((provider) => provider.id === activeProviderId) ??
     routingPlans[0] ??
     null;
   const enabledModelSourceIdsForRefresh = useMemo(() => {
@@ -3003,6 +3004,10 @@ export function CodexRouterWorkspacePage({
   const routeModels = collectRouteModels(routeEntries);
   const selectedPlan =
     routingPlans.find((provider) => provider.id === selectedPlanId) ??
+    // 未显式选中时优先当前激活的 Codex provider（个人版/公司版），
+    // 而不是 routingPlans[0]——后者顺序来自 Object.values(providers)，
+    // 键枚举顺序不稳定，会随机落到某个 plan（用户观察到总是公司版）。
+    routingPlans.find((provider) => provider.id === activeProviderId) ??
     routingPlans[0] ??
     null;
   const selectedRouting = selectedPlan ? readCodexRouting(selectedPlan) : null;


### PR DESCRIPTION
Closes #40

## 概述

Codex 桌面端模型选择菜单（picker）**顺序混乱**：SSOT 恢复 / 启动接管 / 热切换后，模型顺序退化为默认供应商顺序，与用户在 MultiRouter 工作台里手动拖拽的顺序不一致。

同时存在偶发的**工作区错乱**：应用打开时随机落在错误的 provider 工作区（如公司 MultiRouter 而非当前激活的 provider）。

## 根因

两条独立链路：

1. **菜单乱序（排序信息丢失）**：`write_live_with_common_config`（SSOT 恢复 / 启动接管）与 `write_codex_takeover_live_for_provider`（热切换）写 live config 时，从 router 的 **raw `settings_config.modelCatalog`** 读模型——那是**无 `sortIndex` 的旧投影快照**（投影 settings 从不写回 router）。`sort_codex_catalog_specs_for_picker` 读不到 `sortIndex` → 走默认供应商排序 → 菜单乱序。而 UI 显示正确（前端 `projectCodexModelCatalog` 实时投影从 target 读 sortIndex），造成"UI 对、菜单乱"的割裂。
2. **工作区错乱**：`selectedPlan` 兜底 `routingPlans[0]`，其顺序来自 `Object.values(providers)`（对象键枚举序，不稳定），应用打开时随机落在错误的 provider 工作区。

## 修复（4 个 commit，均基于 v3.19.2-16）

- `5ad6e6e3`（1910de21）：`write_live_with_common_config` 对 schema-v2 router 先 `build_projection_artifact`，用**投影 settings**（含 sortIndex + 依赖指纹）写 live，与 `publish_codex_multirouter_projection` 输出一致
- `4fa86cbc`（62316d8f）：takeover 写路径同样改用投影产物（覆盖启动接管 / 热切换 / 回滚路径）
- `d5e1f1df`（ef13f256）：`write_codex_takeover_live_for_provider` 出口**无条件**用投影后的 modelCatalog 覆盖（修复 sync 标志注入 raw modelCatalog 导致投影替换被跳过的问题）
- `7b341b46`（65830284）：workspace 默认选择改为「显式选中 plan → 激活的 codex provider → routingPlans[0]」，消除对象枚举序的不确定性

## 备注

- `build_projection_artifact` 提升为 `pub(crate)` 供 services 层复用
- 涉及文件：`projection.rs` / `services/provider/live.rs` / `services/proxy.rs` / `CodexRouterWorkspacePage.tsx`
