### PR TITLE
fix(codex): project displayName into /v1/models and catalog artifact (closes #42)

### DIFF
--- a/src-tauri/src/codex_multirouter/compiler.rs
+++ b/src-tauri/src/codex_multirouter/compiler.rs
@@ -37,6 +37,7 @@ pub struct CompiledCodexModel {
     pub visible_model: String,
     pub canonical_model: String,
     pub upstream_model: String,
+    pub display_name: String,
     pub target_provider_id: String,
     pub route_id: String,
     pub api_format: String,
@@ -164,6 +165,7 @@ pub fn compile_v2(
                 visible_model,
                 canonical_model: candidate.canonical_model.clone(),
                 upstream_model: candidate.upstream_model.clone(),
+                display_name: model_display_name(candidate.model_entry, &candidate.canonical_model),
                 target_provider_id: candidate.provider.id.clone(),
                 route_id: candidate.route_id.to_string(),
                 api_format,
@@ -362,6 +364,14 @@ fn upstream_model(model_entry: &Value, canonical_model: &str) -> String {
     string_field(model_entry, &["upstreamModel", "upstream_model"])
         .unwrap_or(canonical_model)
         .to_string()
+}
+
+fn model_display_name(model_entry: &Value, canonical_model: &str) -> String {
+    string_field(model_entry, &["displayName", "display_name"])
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| canonical_model.to_string())
 }
 
 fn model_sort_index(model_entry: &Value) -> Option<usize> {

--- a/src-tauri/src/codex_multirouter/projection.rs
+++ b/src-tauri/src/codex_multirouter/projection.rs
@@ -355,6 +355,7 @@ fn projected_model_entry(model: &CompiledCodexModel, sort_index: Option<usize>) 
         "upstreamModel".to_string(),
         Value::String(model.upstream_model.clone()),
     );
+    entry.insert("displayName".to_string(), Value::String(model.display_name.clone()));
     entry.insert(
         "apiFormat".to_string(),
         Value::String(model.api_format.clone()),
@@ -773,5 +774,43 @@ mod tests {
             inspect_codex_multirouter_projection(&db, "router").expect("inspect stale projection");
         assert_eq!(stale.state, ProjectionState::Pending);
         assert_eq!(stale.last_error_code.as_deref(), Some("projection_stale"));
+    }
+
+    #[test]
+    fn projected_models_preserve_display_name_from_source_catalog() {
+        let db = Database::memory().expect("memory db");
+        let router = router();
+        let mut target = Provider::with_id(
+            "qwen".to_string(),
+            "Qwen".to_string(),
+            json!({
+                "base_url": "https://qwen.example/v1",
+                "modelCatalog": {"models": [{
+                    "model": "qwen3.8",
+                    "displayName": "Qwen 3.8 大模型",
+                    "inputModalities": ["text"],
+                    "contextWindow": 262144
+                }]}
+            }),
+            None,
+        );
+        target.meta = Some(ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &router).expect("save router");
+        db.save_provider("codex", &target).expect("save target");
+
+        let artifact = build_projection_artifact(&db, "router").expect("projection artifact");
+        let models = artifact.projection_settings["modelCatalog"]["models"]
+            .as_array()
+            .expect("projected models");
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0]["model"].as_str(), Some("qwen3.8"));
+        assert_eq!(
+            models[0]["displayName"].as_str(),
+            Some("Qwen 3.8 大模型"),
+            "projected model entry must carry displayName from the source catalog"
+        );
     }
 }

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -2391,9 +2391,19 @@ fn openai_model_entry(id: &str, owner: &str) -> Value {
     })
 }
 
-/// 根据 catalog/source 对象构造 OpenAI model entry，透传明确的上下文窗口字段。
+/// 根据 catalog/source 对象构造 OpenAI model entry，透传明确的上下文窗口与显示名字段。
 fn openai_model_entry_with_source(id: &str, owner: &str, source: &Value) -> Value {
     let mut entry = openai_model_entry(id, owner);
+    if let Some(display_name) = extract_model_display_name(source) {
+        if let Some(object) = entry.as_object_mut() {
+            // Codex Desktop 的模型菜单以 `/v1/models` 的 data[] 为主来源，不同版本读取的
+            // 字段名不一致：同时投 snake_case/camelCase/name，renderer 才能用用户改的
+            // 显示名渲染菜单，而不是退化成原始模型 ID。
+            object.insert("display_name".to_string(), json!(display_name));
+            object.insert("displayName".to_string(), json!(display_name));
+            object.insert("name".to_string(), json!(display_name));
+        }
+    }
     if let Some(context_window) = extract_model_context_window(source) {
         if let Some(object) = entry.as_object_mut() {
             // Codex Desktop 不同版本在 `/v1/models` 的 data[] 分支上读取的字段名不完全一致；
@@ -2405,6 +2415,19 @@ fn openai_model_entry_with_source(id: &str, owner: &str, source: &Value) -> Valu
         }
     }
     entry
+}
+
+/// 从 model catalog 条目中读取用户声明的显示名，兼容 snake_case 与 camelCase。
+fn extract_model_display_name(value: &Value) -> Option<String> {
+    const KEYS: &[&str] = &["display_name", "displayName", "name", "title"];
+    KEYS.iter()
+        .filter_map(|key| value.get(*key))
+        .find_map(|name| {
+            name.as_str()
+                .map(str::trim)
+                .filter(|display| !display.is_empty())
+                .map(str::to_string)
+        })
 }
 
 /// 从 model catalog 条目中读取正整数上下文窗口，兼容 snake_case 与 camelCase。
@@ -5671,6 +5694,56 @@ mod tests {
         assert!(
             qwen.get("upstream_model").is_none(),
             "OpenAI-compatible data[] entries must not expose private upstream model aliases"
+        );
+    }
+
+    #[test]
+    fn codex_catalog_models_response_passes_through_display_name() {
+        let response = codex_catalog_models_response(json!({
+            "models": [
+                { "model": "deepseek-v4-flash-deepseek", "display_name": "Deepseek V4 Flash" },
+                { "model": "gpt-5.6-luna", "displayName": "GPT-5.6-Luna" },
+                { "model": "plain-id" }
+            ]
+        }));
+
+        let data = response["data"].as_array().expect("OpenAI data array");
+        let deepseek = data
+            .iter()
+            .find(|entry| entry.get("id").and_then(|id| id.as_str()) == Some("deepseek-v4-flash-deepseek"))
+            .expect("deepseek entry");
+        assert_eq!(
+            deepseek.get("display_name").and_then(|value| value.as_str()),
+            Some("Deepseek V4 Flash")
+        );
+        assert_eq!(
+            deepseek.get("displayName").and_then(|value| value.as_str()),
+            Some("Deepseek V4 Flash")
+        );
+        assert_eq!(
+            deepseek.get("name").and_then(|value| value.as_str()),
+            Some("Deepseek V4 Flash")
+        );
+        let luna = data
+            .iter()
+            .find(|entry| entry.get("id").and_then(|id| id.as_str()) == Some("gpt-5.6-luna"))
+            .expect("luna entry");
+        assert_eq!(
+            luna.get("display_name").and_then(|value| value.as_str()),
+            Some("GPT-5.6-Luna"),
+            "camelCase displayName source must also be projected"
+        );
+        let plain = data
+            .iter()
+            .find(|entry| entry.get("id").and_then(|id| id.as_str()) == Some("plain-id"))
+            .expect("plain entry");
+        assert!(
+            plain.get("display_name").is_none(),
+            "entries without a declared display name must stay id-only"
+        );
+        assert!(
+            deepseek.get("upstreamModel").is_none() && deepseek.get("upstream_model").is_none(),
+            "display-name projection must not leak upstream aliases"
         );
     }
 


### PR DESCRIPTION
Closes #42

## 概述

第三方模型在 Codex 桌面端**显示模型 ID 而非用户自定义的显示名**（如 `deepseek-v4-flash-deepseek` 而不是「DeepSeek V4 Flash」）。用户在 CC Switch 设置里改了 `displayName` 不生效（与 #23 同一现象族）。

## 根因

两条投影链路都丢失了显示名：

1. **`/v1/models` 端点**（handlers.rs）：`openai_model_entry_with_source` 构建模型条目时未透传 `display_name` / `displayName` / `name`，Codex 桌面端模型菜单读取 `data[].display_name` 拿到空值回退到 model ID。
2. **投影产物 modelCatalog**（compiler.rs / projection.rs）：`CompiledCodexModel` 不携带 `displayName`，`projected_model_entry` 重建条目时字段丢失，下游 catalog 文件同样无显示名。

## 修复（2 个 commit，均基于 v3.19.2-16）

- `b70bfd54`（6c6434fd）：handlers.rs `/v1/models` 投影透传 `display_name`/`displayName`/`name`（对齐 context_window 多键策略）
- `2632af59`：compiler.rs `CompiledCodexModel` 携带 displayName + projection.rs `projected_model_entry` 透传，补回归测试 `projected_models_preserve_display_name_from_source_catalog`

## 测试

- 后端 `cargo test --lib`：新增 displayName 投影回归全绿
- `cargo check`：零警告
