### PR TITLE
fix(codex): recognize alias-suffixed flash/pro role models in V2 subagent page (closes #48)

### DIFF
--- a/src/components/codex/CodexRouterWorkspacePage.test.ts
+++ b/src/components/codex/CodexRouterWorkspacePage.test.ts
@@ -2302,6 +2302,46 @@ describe("Codex MultiRouter workspace route persistence helpers", () => {
     expect(screen.getByText("目录中缺失")).toBeInTheDocument();
   });
 
+  it("recognizes alias-suffixed flash/pro role models as routable", async () => {
+    const source: Provider = {
+      id: "codex-deepseek-alias",
+      name: "DeepSeek alias",
+      category: "custom",
+      settingsConfig: {
+        modelCatalog: {
+          models: [
+            { model: "deepseek-v4-flash-deepseek" },
+            { model: "deepseek-v4-pro-deepseek" },
+            { model: "deepseek-v4-flash-vision-exp" },
+          ],
+        },
+      },
+    };
+    const plan = withEnabledProviderRoute(
+      createDraftRoutingPlan([source], [source]),
+      source,
+    );
+
+    renderWorkspace(
+      React.createElement(CodexRouterWorkspacePage, {
+        providers: [source, plan],
+        isProxyRunning: true,
+        isCodexTakeoverActive: true,
+        activeProviderId: plan.id,
+        initialProviderId: plan.id,
+        initialTab: "routes",
+        onEditProvider: vi.fn(),
+        onDeletePlan: vi.fn(),
+        onCreateProvider: vi.fn(),
+      }),
+    );
+
+    await userEvent.click(screen.getByRole("tab", { name: "子 Agent" }));
+
+    expect(screen.getAllByText("可路由")).toHaveLength(2);
+    expect(screen.queryByText("目录中缺失")).not.toBeInTheDocument();
+  });
+
   it("exposes a delete action for routing plans inside the workspace", async () => {
     const source: Provider = {
       id: "codex-qwen",

--- a/src/components/codex/CodexRouterWorkspacePage.tsx
+++ b/src/components/codex/CodexRouterWorkspacePage.tsx
@@ -6108,12 +6108,19 @@ function SpawnAgentCandidatesPanel({
     selectedCatalog.spawnAgentModels.join("\n");
   const spawnAgentMissingPriorityModels =
     diagnostics?.liveConfig.spawnAgentMissingPriorityModels ?? [];
-  const hasFlashRoleModel = selectedCatalog.models.some(
-    (model) => model.model?.trim() === "deepseek-v4-flash",
+  // flash/pro 角色模型可能以别名形态出现在目录中（如 deepseek-v4-flash-deepseek
+  // 由路由 alias 暴露），因此按基名前缀匹配，而非硬编码精确模型 ID。
+  // 注意排除 vision 变体（deepseek-v4-flash-vision-exp 是独立模型，不是 flash 角色）。
+  const isFlashRoleModel = (name: string) =>
+    (name === "deepseek-v4-flash" || name.startsWith("deepseek-v4-flash-")) &&
+    !name.includes("vision");
+  const hasFlashRoleModel = selectedCatalog.models.some((model) =>
+    isFlashRoleModel(model.model?.trim() ?? ""),
   );
-  const hasProRoleModel = selectedCatalog.models.some(
-    (model) => model.model?.trim() === "deepseek-v4-pro",
-  );
+  const hasProRoleModel = selectedCatalog.models.some((model) => {
+    const name = model.model?.trim() ?? "";
+    return name === "deepseek-v4-pro" || name.startsWith("deepseek-v4-pro-");
+  });
 
   useEffect(() => {
     setActiveSubagentVersion(persistedSubagentVersion);


### PR DESCRIPTION
Closes #48

## 概述

V2 子 Agent 角色编辑页中，**别名后缀模型**（如 route alias 暴露的 `deepseek-v4-flash-deepseek`、`deepseek-v4-pro-deepseek`）显示"catalog 中缺失"（missing from catalog），无法正常编辑/选择角色模型，即使该模型已在路由中启用。

## 根因

前端 `hasFlashRoleModel` / `hasProRoleModel`（CodexRouterWorkspacePage.tsx）**硬编码精确模型 ID**（`deepseek-v4-flash` / `deepseek-v4-pro`）。当模型经 route alias 暴露为 `-deepseek` 后缀形式时，精确匹配失败 → 误判"缺失"。而 V4 Flash Vision 实验变体（`deepseek-v4-flash-vision-exp`）又会被前缀匹配误命中，需排除。

## 修复

- 按**基础名前缀**匹配（排除 vision 变体），识别 alias-suffixed 的 flash/pro 角色模型
- 补回归测试覆盖 alias 后缀与 vision 变体排除

## 测试

- 前端 `vitest run`：新增 alias/vision 变体用例全绿
- `tsc --noEmit`：零错误
