### PR TITLE
fix(codex): preserve legacy route metadata in fail-closed v2

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -1781,6 +1781,20 @@ mod codex_router_log_diagnostics_tests {
     }
 
     #[test]
+    fn legacy_default_route_warning_is_secret_free_and_explicitly_fail_closed() {
+        let warning = codex_legacy_default_route_warning(Some("legacy-route"))
+            .expect("legacy default route should produce a warning");
+
+        assert!(warning.starts_with("default_route_legacy_ignored:"));
+        assert!(warning.contains("请求会被拒绝"));
+        assert!(warning.contains("legacy-route"));
+        assert!(!warning.contains("OPENAI_API_KEY"));
+        assert!(!warning.contains("https://"));
+        assert_eq!(codex_legacy_default_route_warning(Some("  ")), None);
+        assert_eq!(codex_legacy_default_route_warning(None), None);
+    }
+
+    #[test]
     fn enabled_websocket_transport_keeps_probe_failure_visible() {
         let (status, detail) =
             codex_websocket_probe_result(Some(true), Err("probe failed".to_string()));

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -297,6 +297,17 @@ pub async fn diagnose_codex_multirouter(
     let desktop_runtime = codex_desktop_runtime_diagnostics(&live_config);
 
     let mut checks = Vec::new();
+    if let Some(warning) =
+        codex_legacy_default_route_warning(route_plan.default_route_id.as_deref())
+    {
+        checks.push(codex_check(
+            "default_route_legacy_ignored",
+            "旧版默认路由字段",
+            CodexDiagnosticStatus::Warn,
+            warning,
+            vec!["defaultRouteId 仅作为兼容字段读取".to_string()],
+        ));
+    }
     checks.push(codex_check(
         "proxy_running",
         "本地代理进程",
@@ -1239,6 +1250,20 @@ fn codex_url_points_to_local_proxy(url: &str, proxy_port: u16) -> bool {
     };
     let is_local_host = matches!(host, "127.0.0.1" | "localhost" | "::1");
     is_local_host && parsed.port_or_known_default() == Some(proxy_port)
+}
+
+/// Explain the compatibility-only status of a legacy default route field.
+///
+/// The current V2 resolver is fail-closed, so retaining this field must never
+/// be presented as an active fallback. Only the route id is echoed; credentials,
+/// endpoints and provider settings are intentionally excluded from diagnostics.
+fn codex_legacy_default_route_warning(default_route_id: Option<&str>) -> Option<String> {
+    let route_id = default_route_id?.trim();
+    (!route_id.is_empty()).then(|| {
+        format!(
+            "default_route_legacy_ignored: 当前版本未命中请求会被拒绝；defaultRouteId 仅作为旧版兼容字段保留（route id `{route_id}`）。"
+        )
+    })
 }
 
 /// 读取当前页面选择的 MultiRouter provider，并汇总 `codexRouting` 规则。

--- a/src/components/codex/CodexRouterWorkspacePage.test.ts
+++ b/src/components/codex/CodexRouterWorkspacePage.test.ts
@@ -548,6 +548,9 @@ describe("Codex MultiRouter workspace route persistence helpers", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText(/旧版默认路由已停用/)).toBeInTheDocument();
     expect(screen.getByText(/旧配置指向.*DeepSeek Relay/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/保存设置和路由规则时会保留该兼容字段/),
+    ).toBeInTheDocument();
     expect(screen.queryByText(legacyRouteId)).not.toBeInTheDocument();
   });
 
@@ -3787,7 +3790,7 @@ describe("Codex MultiRouter workspace route persistence helpers", () => {
     expect(readCodexRouting(updated)?.routes).toEqual(
       readCodexRouting(savedPlan)?.routes,
     );
-    expect(readCodexRouting(updated)?.defaultRouteId).toBeUndefined();
+    expect(readCodexRouting(updated)?.defaultRouteId).toBe("codex-qwen");
     expect(updated.settingsConfig.hostedTools).toEqual({
       webSearch: { enabled: false },
       imageGeneration: { enabled: true },

--- a/src/components/codex/CodexRouterWorkspacePage.tsx
+++ b/src/components/codex/CodexRouterWorkspacePage.tsx
@@ -2246,7 +2246,15 @@ export function applyMultiRouterSettingsDraft(
               : route,
           ),
         };
-  delete nextRouting.defaultRouteId;
+  const defaultRouteId = currentRouting.defaultRouteId?.trim();
+  if (
+    defaultRouteId &&
+    (nextRouting.routes ?? []).some((route) => route.id === defaultRouteId)
+  ) {
+    nextRouting.defaultRouteId = defaultRouteId;
+  } else {
+    delete nextRouting.defaultRouteId;
+  }
 
   return {
     ...plan,
@@ -3310,13 +3318,21 @@ export function CodexRouterWorkspacePage({
       normalizedRouteDrafts,
       routableProvidersById,
     );
+    const defaultRouteId = currentRouting.defaultRouteId?.trim();
     const nextRouting: CodexRouting = {
       ...currentRouting,
       schemaVersion: 2,
       enabled: currentRouting.enabled ?? true,
       routes: normalizedRoutes,
     };
-    delete nextRouting.defaultRouteId;
+    if (
+      defaultRouteId &&
+      normalizedRoutes.some((route) => route.id === defaultRouteId)
+    ) {
+      nextRouting.defaultRouteId = defaultRouteId;
+    } else {
+      delete nextRouting.defaultRouteId;
+    }
     const nextProvider: Provider = {
       ...plan,
       settingsConfig: {
@@ -5193,7 +5209,8 @@ function MultiRouterSettingsPanel({
               <span className="font-semibold">旧版默认路由已停用</span>
               <span className="leading-5">
                 旧配置指向「{legacyDefaultRouteName ?? "已删除的路由"}」。
-                严格路由不会使用它；保存设置后会自动清除该兼容字段。
+                严格路由不会使用它；保存设置和路由规则时会保留该兼容字段。
+                它只用于兼容展示，不参与当前转发。
               </span>
             </div>
           )}


### PR DESCRIPTION
Closes #56

## 变更摘要

本 PR 补齐 Codex v2 fail-closed 语义的兼容性边界：旧 `defaultRouteId` 仍可读、可保存、可诊断，但不会重新成为运行时兜底入口。

## 关键改动

- 普通 MultiRouter 设置保存会保留仍指向现有 route 的旧 `defaultRouteId`。
- 路由规则保存会同样保留有效旧字段；如果目标 route 已不存在，则安全清理失效字段。
- 诊断新增 `default_route_legacy_ignored` 警告，明确说明未命中请求会被拒绝。
- 诊断只回显 route id，不输出密钥、端点或完整配置。
- 更新前端回归断言，确保兼容字段不会被静默丢弃。

## 验证结果

- `pnpm exec vitest run src/components/codex/CodexRouterWorkspacePage.test.ts src/lib/codexMultiRouterWizard.test.ts`：78 passed / 0 failed
- `pnpm exec tsc --noEmit`：通过
- `pnpm exec prettier --check src/components/codex/CodexRouterWorkspacePage.tsx src/components/codex/CodexRouterWorkspacePage.test.ts`：通过
- `cargo test --lib legacy_default_route_warning_is_secret_free_and_explicitly_fail_closed`：1 passed / 0 failed
- `git diff --check`：通过

## 风险与回滚

改动只影响旧兼容字段的保存和诊断展示，不改变已存在的严格路由匹配逻辑。回滚本 PR 两个提交即可。

## 关联 Issue

- #56