### PR TITLE
fix(startup): guard recovery and proxy port ownership

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "rust_decimal",
  "rustls",
  "rustls-native-certs",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -81,6 +81,7 @@ rustls = "0.23"
 webpki-roots = "0.26"
 rustls-native-certs = "0.8"
 regex = "1.10"
+semver = "1"
 rquickjs = { version = "0.8", features = ["array-buffer", "classes"] }
 thiserror = "2.0"
 anyhow = "1.0"
@@ -121,6 +122,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_Graphics_Gdi",
     "Win32_Storage_FileSystem",
     "Win32_System_LibraryLoader",
+    "Win32_System_Threading",
     "Win32_UI_Controls",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",

--- a/src-tauri/src/app_exit_monitor.rs
+++ b/src-tauri/src/app_exit_monitor.rs
@@ -24,17 +24,57 @@ pub fn init_app_config_dir(dir: PathBuf) {
     let _ = APP_CONFIG_DIR.set(dir);
 }
 
-/// 记录应用启动，并检查上次是否存在未清理的运行 marker。
+/// 上一次运行的证据分类。
 ///
-/// 返回 `Some` 表示上次进程没有走正常退出记录。调用方可以据此打 warn 日志或在 UI
-/// 层后续提示用户查看日志目录。
-pub fn record_startup() -> Option<PreviousRunReport> {
-    let previous = read_run_marker();
-    if let Some(marker) = previous.as_ref() {
-        let report = PreviousRunReport {
-            marker: marker.clone(),
-            crash_log_modified_at: file_modified_at(crash_log_path()),
-        };
+/// 分类先判断旧 PID 是否仍活跃，再判断同一 PID 的 panic/crash 和计划退出证据；只有
+/// 没有更强证据时才归为 `UncleanExit`。这样单独残留 marker 不会触发破坏性恢复。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreviousRunClassification {
+    NoPreviousRun,
+    ActivePreviousInstance,
+    ConfirmedCrash,
+    PlannedRestartOrUpdate,
+    UncleanExit,
+}
+
+impl PreviousRunClassification {
+    pub fn allows_recovery(self) -> bool {
+        matches!(self, Self::ConfirmedCrash | Self::UncleanExit)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupRecoveryReport {
+    pub previous: Option<PreviousRunReport>,
+    pub classification: PreviousRunClassification,
+}
+
+/// 记录应用启动，并在覆盖 marker 前读取完整的旧运行证据。
+pub fn record_startup_report() -> StartupRecoveryReport {
+    let previous_marker = read_run_marker();
+    let previous = previous_marker.as_ref().map(|marker| PreviousRunReport {
+        marker: marker.clone(),
+        crash_log_modified_at: file_modified_at(crash_log_path()),
+    });
+    let events = read_exit_events();
+    let crash_log_modified_after_marker = previous.as_ref().is_some_and(|report| {
+        report
+            .crash_log_modified_at
+            .as_deref()
+            .is_some_and(|modified| modified > report.marker.started_at.as_str())
+    });
+    let classification = classify_previous_run(
+        previous.as_ref().map(|report| &report.marker),
+        &events,
+        crash_log_modified_after_marker,
+        previous
+            .as_ref()
+            .is_some_and(|report| process_is_active(report.marker.pid)),
+    );
+
+    if let Some(report) = previous.as_ref() {
         append_event(
             "abnormal_exit_detected",
             "previous run marker remained at startup",
@@ -42,6 +82,7 @@ pub fn record_startup() -> Option<PreviousRunReport> {
             Some(json!({
                 "previousRun": report.marker,
                 "crashLogModifiedAt": report.crash_log_modified_at,
+                "classification": classification,
             })),
         );
     }
@@ -61,10 +102,16 @@ pub fn record_startup() -> Option<PreviousRunReport> {
         log::warn!("写入应用运行 marker 失败: {err}");
     }
 
-    previous.map(|marker| PreviousRunReport {
-        marker,
-        crash_log_modified_at: file_modified_at(crash_log_path()),
-    })
+    StartupRecoveryReport {
+        previous,
+        classification,
+    }
+}
+
+/// 兼容旧调用方：仍返回旧 marker，但内部使用新的证据分类流程。
+#[allow(dead_code)]
+pub fn record_startup() -> Option<PreviousRunReport> {
+    record_startup_report().previous
 }
 
 /// 记录一次正常退出，并清理运行 marker。
@@ -139,7 +186,7 @@ pub struct RunMarker {
     pub cwd: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ExitEvent {
     timestamp: String,
@@ -151,6 +198,91 @@ struct ExitEvent {
     arch: String,
     pid: u32,
     details: Option<Value>,
+}
+
+fn classify_previous_run(
+    marker: Option<&RunMarker>,
+    events: &[ExitEvent],
+    crash_log_modified_after_marker: bool,
+    pid_active: bool,
+) -> PreviousRunClassification {
+    let Some(marker) = marker else {
+        return PreviousRunClassification::NoPreviousRun;
+    };
+    if pid_active {
+        return PreviousRunClassification::ActivePreviousInstance;
+    }
+
+    let same_pid_events = events
+        .iter()
+        .filter(|event| event.pid == marker.pid && event.timestamp >= marker.started_at);
+    let mut confirmed_crash = crash_log_modified_after_marker;
+    let mut planned_restart = false;
+    for event in same_pid_events {
+        if matches!(event.kind.as_str(), "panic" | "forced_exit") {
+            confirmed_crash = true;
+        }
+        if event.kind == "clean_exit" && is_planned_exit_reason(&event.reason) {
+            planned_restart = true;
+        }
+    }
+    if confirmed_crash {
+        PreviousRunClassification::ConfirmedCrash
+    } else if planned_restart {
+        PreviousRunClassification::PlannedRestartOrUpdate
+    } else {
+        PreviousRunClassification::UncleanExit
+    }
+}
+
+fn is_planned_exit_reason(reason: &str) -> bool {
+    let lower = reason.trim().to_ascii_lowercase();
+    lower.contains("restart") || lower.contains("update") || lower.contains("reload")
+}
+
+fn read_exit_events() -> Vec<ExitEvent> {
+    fs::read_to_string(exit_events_path())
+        .ok()
+        .into_iter()
+        .flat_map(|text| {
+            text.lines()
+                .filter_map(|line| serde_json::from_str::<ExitEvent>(line).ok())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn process_is_active(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+        // A read-only process handle is enough to distinguish an active old instance.
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            false
+        } else {
+            unsafe { CloseHandle(handle) };
+            true
+        }
+    }
+    #[cfg(all(unix, not(target_os = "windows")))]
+    {
+        // kill(pid, 0) performs an existence/permission check without sending a signal.
+        unsafe {
+            libc::kill(pid as libc::pid_t, 0) == 0
+                || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+        }
+    }
+    #[cfg(not(any(unix, target_os = "windows")))]
+    {
+        false
+    }
 }
 
 fn append_event(kind: &str, reason: &str, exit_code: Option<i32>, details: Option<Value>) {
@@ -256,5 +388,107 @@ mod tests {
         let text = serde_json::to_string(&event).expect("serialize event");
         assert!(text.contains("\"kind\":\"clean_exit\""));
         assert!(text.contains("\"exitCode\":0"));
+    }
+
+    fn marker(pid: u32, started_at: &str) -> RunMarker {
+        RunMarker {
+            started_at: started_at.to_string(),
+            pid,
+            version: "test".to_string(),
+            os: "test".to_string(),
+            arch: "test".to_string(),
+            cwd: "test".to_string(),
+        }
+    }
+
+    fn event(pid: u32, timestamp: &str, kind: &str, reason: &str) -> ExitEvent {
+        ExitEvent {
+            timestamp: timestamp.to_string(),
+            kind: kind.to_string(),
+            reason: reason.to_string(),
+            exit_code: None,
+            version: "test".to_string(),
+            os: "test".to_string(),
+            arch: "test".to_string(),
+            pid,
+            details: None,
+        }
+    }
+
+    #[test]
+    fn classification_without_marker_is_no_previous_run() {
+        assert_eq!(
+            classify_previous_run(None, &[], false, false),
+            PreviousRunClassification::NoPreviousRun
+        );
+    }
+
+    #[test]
+    fn active_previous_instance_takes_priority_over_crash_evidence() {
+        let old = marker(42, "2026-08-24 10:00:00.000");
+        let events = vec![event(42, "2026-08-24 10:01:00.000", "panic", "panic")];
+
+        assert_eq!(
+            classify_previous_run(Some(&old), &events, true, true),
+            PreviousRunClassification::ActivePreviousInstance
+        );
+    }
+
+    #[test]
+    fn same_pid_panic_or_crash_log_is_confirmed_crash() {
+        let old = marker(42, "2026-08-24 10:00:00.000");
+        let events = vec![event(42, "2026-08-24 10:01:00.000", "panic", "panic")];
+
+        assert_eq!(
+            classify_previous_run(Some(&old), &events, false, false),
+            PreviousRunClassification::ConfirmedCrash
+        );
+        assert_eq!(
+            classify_previous_run(Some(&old), &[], true, false),
+            PreviousRunClassification::ConfirmedCrash
+        );
+    }
+
+    #[test]
+    fn same_pid_planned_exit_is_planned_restart_or_update() {
+        let old = marker(42, "2026-08-24 10:00:00.000");
+        let events = vec![event(
+            42,
+            "2026-08-24 10:01:00.000",
+            "clean_exit",
+            "update and restart",
+        )];
+
+        assert_eq!(
+            classify_previous_run(Some(&old), &events, false, false),
+            PreviousRunClassification::PlannedRestartOrUpdate
+        );
+    }
+
+    #[test]
+    fn stale_marker_without_matching_evidence_is_unclean_exit() {
+        let old = marker(42, "2026-08-24 10:00:00.000");
+        let events = vec![event(42, "2026-08-24 09:59:00.000", "panic", "old")];
+
+        assert_eq!(
+            classify_previous_run(Some(&old), &events, false, false),
+            PreviousRunClassification::UncleanExit
+        );
+    }
+
+    #[test]
+    fn different_pid_events_cannot_change_classification() {
+        let old = marker(42, "2026-08-24 10:00:00.000");
+        let events = vec![event(
+            99,
+            "2026-08-24 10:01:00.000",
+            "clean_exit",
+            "restart",
+        )];
+
+        assert_eq!(
+            classify_previous_run(Some(&old), &events, false, false),
+            PreviousRunClassification::UncleanExit
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -501,14 +501,19 @@ pub fn run() {
             // 放在日志系统初始化之后，确保 init 的日志能正常输出。
             usage_events::init(app.handle().clone());
 
-            if let Some(previous) = app_exit_monitor::record_startup() {
-                log::warn!(
-                    "检测到上次应用未正常退出: started_at={}, pid={}, crash_log_modified_at={:?}",
-                    previous.marker.started_at,
-                    previous.marker.pid,
-                    previous.crash_log_modified_at
-                );
-            }
+            let startup_recovery_classification = {
+                let startup = app_exit_monitor::record_startup_report();
+                if let Some(previous) = startup.previous.as_ref() {
+                    log::warn!(
+                        "检测到上次应用未正常退出: started_at={}, pid={}, crash_log_modified_at={:?}",
+                        previous.marker.started_at,
+                        previous.marker.pid,
+                        previous.crash_log_modified_at
+                    );
+                }
+                log::info!("启动恢复证据分类: {:?}", startup.classification);
+                startup.classification
+            };
 
             let launch_on_startup = crate::settings::get_settings().launch_on_startup;
             if let Err(error) = crate::auto_launch::reconcile_auto_launch(launch_on_startup) {
@@ -1253,13 +1258,20 @@ pub fn run() {
                 // 检查 Live 配置是否仍处于被接管状态（包含占位符）
                 let live_taken_over = state.proxy_service.detect_takeover_in_live_configs();
 
-                if has_backups || live_taken_over {
+                if (has_backups || live_taken_over)
+                    && startup_recovery_classification.allows_recovery()
+                {
                     log::warn!("检测到上次异常退出（存在接管残留），正在恢复 Live 配置...");
                     if let Err(e) = state.proxy_service.recover_from_crash().await {
                         log::error!("恢复 Live 配置失败: {e}");
                     } else {
                         log::info!("Live 配置已恢复");
                     }
+                } else if has_backups || live_taken_over {
+                    log::info!(
+                        "跳过启动恢复：上次运行分类为 {:?}",
+                        startup_recovery_classification
+                    );
                 }
 
                 // 必须排在 auto-extract 之前：先把历史泄漏进 Gemini 共享片段的凭据
@@ -2082,6 +2094,12 @@ async fn restore_proxy_state_on_startup(state: &store::AppState) {
             }
             Err(e) => {
                 log::error!("✗ 恢复 {app_type} 的代理接管状态失败: {e}");
+                if crate::services::proxy::is_port_ownership_guard_error(&e) {
+                    log::warn!(
+                        "保留 {app_type} 代理状态：端口所有权未确认，跳过关闭接管和破坏性清理"
+                    );
+                    continue;
+                }
                 // 失败时清除该应用的状态，避免下次启动再次尝试
                 if let Err(clear_err) = state
                     .proxy_service

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -160,6 +160,10 @@ impl ProxyServer {
         status.running = true;
         status.address = self.config.listen_address.clone();
         status.port = actual_port;
+        status.app = Some("ccswitchmulti".to_string());
+        status.version = Some(env!("CARGO_PKG_VERSION").to_string());
+        status.pid = Some(std::process::id());
+        status.instance_id = Some(uuid::Uuid::new_v4().to_string());
         drop(status);
 
         // 记录启动时间

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -89,6 +89,18 @@ pub struct ProxyStatus {
     /// 当前活跃的代理目标列表
     #[serde(default)]
     pub active_targets: Vec<ActiveTarget>,
+    /// 稳定应用标识，用于端口占用者兼容性探测。
+    #[serde(default)]
+    pub app: Option<String>,
+    /// 运行中的应用版本，用于同主版本兼容性判断。
+    #[serde(default)]
+    pub version: Option<String>,
+    /// 监听该端口的进程 ID。
+    #[serde(default)]
+    pub pid: Option<u32>,
+    /// 本次代理实例的唯一标识；旧实例缺失时仍保持兼容。
+    #[serde(default)]
+    pub instance_id: Option<String>,
 }
 
 /// 活跃的代理目标信息

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -14,6 +14,7 @@ use crate::proxy::{external_openai_api, server::ProxyServer};
 use crate::services::provider::{
     build_effective_settings_with_common_config, write_live_with_common_config,
 };
+use semver::Version;
 use serde_json::{json, Map, Value};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -23,8 +24,107 @@ use toml_edit::{DocumentMut, Item, TableLike};
 
 /// 用于接管 Live 配置时的占位符（避免客户端提示缺少 key，同时不泄露真实 Token）
 const PROXY_TOKEN_PLACEHOLDER: &str = "PROXY_MANAGED";
+const PORT_OWNERSHIP_GUARD_PREFIX: &str = "PORT_OWNERSHIP_GUARD";
 /// Codex 接管时暴露给官方客户端的本地代理入口名称。
 const CODEX_LOCAL_PROXY_PROVIDER_NAME: &str = "CCSwitch MultiRouter";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PortOwnership {
+    CompatibleInstance,
+    UnknownOwner,
+    Unreachable,
+}
+
+pub(crate) fn is_port_ownership_guard_error(error: &str) -> bool {
+    error.starts_with(PORT_OWNERSHIP_GUARD_PREFIX)
+}
+
+/// 检查端口上的 HTTP 服务是否能证明自己是兼容的 CCSwitchMulti 实例。
+///
+/// 端口探测只读 `/health` 和 `/status`，绝不终止或修改占用端口的进程。缺少
+/// 必要身份字段、版本不合法或响应无法解析时一律按未知占用者处理，避免误接管。
+pub(crate) async fn probe_proxy_port(port: u16) -> PortOwnership {
+    if port == 0 {
+        return PortOwnership::Unreachable;
+    }
+
+    let client = match reqwest::Client::builder()
+        .no_proxy()
+        .timeout(std::time::Duration::from_millis(350))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return PortOwnership::Unreachable,
+    };
+    let base = format!("http://127.0.0.1:{port}");
+
+    let health = match client.get(format!("{base}/health")).send().await {
+        Ok(response) if response.status().is_success() => response,
+        Ok(_) => return PortOwnership::UnknownOwner,
+        Err(_) => return PortOwnership::Unreachable,
+    };
+    match health.json::<Value>().await {
+        Ok(value) if value.is_object() => {}
+        Ok(_) | Err(_) => return PortOwnership::UnknownOwner,
+    }
+
+    let status = match client.get(format!("{base}/status")).send().await {
+        Ok(response) if response.status().is_success() => response,
+        Ok(_) => return PortOwnership::UnknownOwner,
+        Err(_) => return PortOwnership::Unreachable,
+    };
+    let payload = match status.json::<Value>().await {
+        Ok(payload) => payload,
+        Err(_) => return PortOwnership::UnknownOwner,
+    };
+
+    if is_compatible_proxy_identity(&payload) {
+        PortOwnership::CompatibleInstance
+    } else {
+        PortOwnership::UnknownOwner
+    }
+}
+
+fn is_compatible_proxy_identity(payload: &Value) -> bool {
+    let app_matches = payload
+        .get("app")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|app| {
+            app.eq_ignore_ascii_case("ccswitchmulti")
+                || app.eq_ignore_ascii_case("cc-switch")
+                || app.eq_ignore_ascii_case("cc_switch")
+        });
+    if !app_matches {
+        return false;
+    }
+
+    let Some(remote_version) = payload.get("version").and_then(Value::as_str) else {
+        return false;
+    };
+    let Ok(remote_version) = Version::parse(remote_version.trim()) else {
+        return false;
+    };
+    let Ok(local_version) = Version::parse(env!("CARGO_PKG_VERSION")) else {
+        return false;
+    };
+    if remote_version.major != local_version.major {
+        return false;
+    }
+
+    let Some(pid) = payload.get("pid").and_then(Value::as_u64) else {
+        return false;
+    };
+    if pid == 0 || pid > u32::MAX as u64 {
+        return false;
+    }
+
+    match payload.get("instance_id") {
+        None => true,
+        Some(Value::String(instance_id)) => !instance_id.trim().is_empty(),
+        Some(_) => false,
+    }
+}
 
 fn should_run_codex_post_takeover(app_type: &AppType) -> bool {
     matches!(app_type, AppType::Codex)
@@ -862,7 +962,34 @@ impl ProxyService {
         if enabled {
             // 1) 代理服务未运行则自动启动
             if !self.is_running().await {
-                self.start().await?;
+                match self.start().await {
+                    Ok(_) => {}
+                    Err(start_error) => {
+                        let listen_port = self
+                            .db
+                            .get_proxy_config()
+                            .await
+                            .map_err(|e| format!("获取代理端口失败: {e}"))?
+                            .listen_port;
+                        match probe_proxy_port(listen_port).await {
+                            PortOwnership::CompatibleInstance => {
+                                log::warn!(
+                                    "端口 {listen_port} 已由兼容 CCSwitchMulti 实例占用，跳过本实例启动并复用该端口"
+                                );
+                            }
+                            PortOwnership::UnknownOwner => {
+                                return Err(format!(
+                                    "{PORT_OWNERSHIP_GUARD_PREFIX}: 代理端口 {listen_port} 的占用者无法安全确认；CCSwitchMulti 不会结束该进程，也不会启用接管（原始错误: {start_error}）"
+                                ));
+                            }
+                            PortOwnership::Unreachable => {
+                                return Err(format!(
+                                    "{PORT_OWNERSHIP_GUARD_PREFIX}: 代理端口 {listen_port} 启动失败且无法识别占用者；CCSwitchMulti 不会结束该进程，也不会启用接管（原始错误: {start_error}）"
+                                ));
+                            }
+                        }
+                    }
+                }
             }
 
             // 2) 已接管则直接返回（幂等）；但如果缺少备份或占位符残留，需要重建接管
@@ -4396,6 +4523,192 @@ mod tests {
         assert!(should_run_codex_post_takeover(&AppType::Codex));
         assert!(!should_run_codex_post_takeover(&AppType::Claude));
         assert!(!should_run_codex_post_takeover(&AppType::Gemini));
+    }
+
+    #[test]
+    fn proxy_identity_parser_accepts_legacy_instance_id_omission() {
+        let local_major = Version::parse(env!("CARGO_PKG_VERSION"))
+            .expect("local package version")
+            .major;
+        assert!(is_compatible_proxy_identity(&json!({
+            "app": "CCSwitchMulti",
+            "version": format!("{local_major}.99.0-beta.1"),
+            "pid": 4242,
+        })));
+    }
+
+    #[test]
+    fn proxy_identity_parser_fails_closed_for_invalid_identity() {
+        let local_major = Version::parse(env!("CARGO_PKG_VERSION"))
+            .expect("local package version")
+            .major;
+        let compatible_version = format!("{local_major}.99.0");
+        let invalid_payloads = [
+            json!({
+                "app": "",
+                "version": compatible_version,
+                "pid": 4242,
+            }),
+            json!({
+                "app": "OtherService",
+                "version": compatible_version,
+                "pid": 4242,
+            }),
+            json!({
+                "app": "CCSwitchMulti",
+                "version": "not-semver",
+                "pid": 4242,
+            }),
+            json!({
+                "app": "CCSwitchMulti",
+                "version": format!("{}.0.0", local_major + 1),
+                "pid": 4242,
+            }),
+            json!({
+                "app": "CCSwitchMulti",
+                "version": compatible_version,
+                "pid": 0,
+            }),
+            json!({
+                "app": "CCSwitchMulti",
+                "version": compatible_version,
+                "pid": u64::from(u32::MAX) + 1,
+            }),
+            json!({
+                "app": "CCSwitchMulti",
+                "version": compatible_version,
+                "pid": 4242,
+                "instance_id": "   ",
+            }),
+            json!({
+                "app": "CCSwitchMulti",
+                "version": compatible_version,
+                "pid": 4242,
+                "instance_id": 7,
+            }),
+        ];
+
+        for payload in invalid_payloads {
+            assert!(
+                !is_compatible_proxy_identity(&payload),
+                "payload must be rejected: {payload}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn port_probe_reads_health_and_status_from_local_listener() {
+        use axum::{routing::get, Json, Router};
+
+        let local_major = Version::parse(env!("CARGO_PKG_VERSION"))
+            .expect("local package version")
+            .major;
+        let app = Router::new()
+            .route(
+                "/health",
+                get(|| async { Json(json!({ "status": "healthy" })) }),
+            )
+            .route(
+                "/status",
+                get(move || async move {
+                    Json(json!({
+                        "app": "ccswitchmulti",
+                        "version": format!("{local_major}.1.0"),
+                        "pid": 4242,
+                        "instance_id": "listener-test",
+                    }))
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind compatible listener");
+        let port = listener.local_addr().expect("listener address").port();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve compatible listener");
+        });
+
+        assert_eq!(
+            probe_proxy_port(port).await,
+            PortOwnership::CompatibleInstance
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn port_probe_rejects_non_json_and_unknown_listeners() {
+        use axum::{routing::get, Router};
+
+        let app = Router::new()
+            .route("/health", get(|| async { "healthy" }))
+            .route("/status", get(|| async { "not-json" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind unknown listener");
+        let port = listener.local_addr().expect("listener address").port();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve unknown listener");
+        });
+
+        assert_eq!(probe_proxy_port(port).await, PortOwnership::UnknownOwner);
+        task.abort();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn unknown_port_owner_does_not_enable_takeover_or_stop_listener() {
+        use axum::{routing::get, Json, Router};
+
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().expect("init db"));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind unknown owner");
+        let port = listener.local_addr().expect("listener address").port();
+        let mut config = db.get_proxy_config().await.expect("get proxy config");
+        config.listen_address = "127.0.0.1".to_string();
+        config.listen_port = port;
+        db.update_proxy_config(config)
+            .await
+            .expect("persist occupied port");
+
+        let app = Router::new()
+            .route(
+                "/health",
+                get(|| async { Json(json!({ "status": "healthy" })) }),
+            )
+            .route(
+                "/status",
+                get(|| async { Json(json!({ "app": "other", "version": "1.0.0", "pid": 1 })) }),
+            );
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve unknown owner");
+        });
+
+        let service = ProxyService::new(db.clone());
+        let error = service
+            .set_takeover_for_app("codex", true)
+            .await
+            .expect_err("unknown owner must stop takeover");
+        assert!(is_port_ownership_guard_error(&error));
+        assert!(!service.is_running().await);
+        assert!(
+            !db.get_proxy_config_for_app("codex")
+                .await
+                .expect("get takeover config")
+                .enabled
+        );
+
+        let response = reqwest::get(format!("http://127.0.0.1:{port}/status"))
+            .await
+            .expect("unknown owner remains reachable");
+        assert!(response.status().is_success());
+        task.abort();
     }
 
     async fn running_codex_base_url(service: &ProxyService) -> String {


### PR DESCRIPTION
Fixes #50. Classifies previous runs before recovery, publishes optional proxy identity fields, probes /health and /status with same-major SemVer and valid PID checks, and fails closed without killing unknown listeners or enabling takeover. Validation: targeted Rust tests, cargo fmt check, git diff check.