### PR TITLE
fix(codex): skip startup catalog projection when takeover is disabled

### DIFF
--- a/docs/release-notes/v3.19.2-18.7-zh.md
+++ b/docs/release-notes/v3.19.2-18.7-zh.md
@@ -1,0 +1,6 @@
+# v3.19.2-18.7
+
+## 修复
+
+- **关闭 Codex 本地托管时不再启动模型目录重投影**：启动对账现在必须确认 `proxy_config.codex.enabled=true` 才会刷新 CCSwitchMulti 自有目录。关闭托管后残留的旧 `model_catalog_json` 指针不再被误认为 CCSwitchMulti 仍拥有该目录，因此不会在单纯打开 CCSM 时覆盖用户对模型目录的隐藏/排序设置。
+- 保留本地托管已启用时的目录刷新能力，用于升级后修复真正托管状态下的过期能力字段。

--- a/docs/testing/codex-startup-projection-v3.19.2-18.7.tdd.md
+++ b/docs/testing/codex-startup-projection-v3.19.2-18.7.tdd.md
@@ -1,0 +1,36 @@
+# Codex 启动模型目录对账 18.7 TDD 证据
+
+## 来源
+
+本次没有外部 `*.plan.md`；用户旅程根据问题现场整理。
+
+## 用户旅程
+
+作为没有开启 Codex 本地托管或 MultiRouter 的用户，我希望打开 CCSwitchMulti 不会自动重写模型目录，以便保留我已经隐藏或排序的模型。
+
+作为已经开启 Codex 本地托管的用户，我希望启动时仍能刷新 CCSwitchMulti 自有目录，以便升级后修复过期的模型能力字段。
+
+## RED / GREEN 证据
+
+| 保证 | 测试与验证 | 结果 |
+|---|---|---|
+| Codex 托管关闭、Live 仍残留旧 `model_catalog_json` 指针时，启动对账不写目录 | `cargo test --lib services::proxy::tests::codex_startup_skips_owned_catalog_when_takeover_disabled -- --exact --nocapture`（修复前） | RED：测试执行后在 `proxy.rs:6109` 断言失败 |
+| 同一场景在修复后保持目录中的旧字段不变 | 同上（修复后） | GREEN：`1 passed; 0 failed` |
+| Codex 托管启用时，幂等刷新仍修复过期目录字段 | `cargo test --lib services::proxy::tests::codex_idempotent_takeover_refreshes_stale_owned_model_catalog -- --exact --nocapture` | GREEN：`1 passed; 0 failed` |
+| Codex 相关代理、恢复、切换回归不受影响 | `cargo test --lib services::proxy::tests::codex_ -- --nocapture` | GREEN：`37 passed; 0 failed` |
+| 前端现有单元与集成测试保持通过 | `pnpm test:unit` | GREEN：`148 passed; 1213 passed` |
+| TypeScript 类型保持正确 | `pnpm typecheck` | GREEN；首次因工作树缺少已锁定的 `pinyin-pro` 依赖而失败，执行 `pnpm install --frozen-lockfile` 后通过 |
+
+## 修复保证
+
+`reconcile_codex_owned_projection_on_startup` 现在先读取 `proxy_config.codex.enabled`。只有该值为 `true` 时，旧目录指针才会进入自有目录对账；关闭托管时直接返回 `Ok(false)`，不会调用 `takeover_live_config_best_effort`，也不会重写生成目录。
+
+版本元数据已经统一为 `3.19.2-18.7`，并新增 18.7 中文发布说明。
+
+## 覆盖率与已知缺口
+
+仓库没有配置 Rust 覆盖率脚本，环境也没有安装 `cargo-llvm-cov`，因此本次没有虚报 80% 覆盖率。已执行受影响的 37 个 Rust Codex 测试和完整前端 Vitest 套件；真实桌面启动/E2E 未在本次环境中执行。
+
+## 合并证据
+
+本次没有创建 checkpoint commit，因为用户尚未授权提交或推送；当前改动保留在 18.7 修复分支工作树中，方便世豪审阅后再决定是否提交。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch-multi",
-  "version": "3.19.2-18",
+    "version": "3.19.2-18.7",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.19.2-18"
+version = "3.19.2-18.7"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-switch"
-version = "3.19.2-18"
+  version = "3.19.2-18.7"
 description = "All-in-One Assistant for Claude Code, Codex & Gemini CLI"
 authors = ["Jason Young"]
 license = "MIT"

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1744,10 +1744,21 @@ impl ProxyService {
         }
     }
 
-    /// Refresh a CCSwitchMulti-owned Codex catalog on application startup even
-    /// when the persisted takeover flag has drifted. A user-managed external
-    /// catalog is never rewritten.
+    /// Refresh a CCSwitchMulti-owned Codex catalog on application startup only
+    /// while Codex takeover is enabled. A stale generated-catalog pointer in
+    /// Live config is not ownership proof after takeover has been disabled, so
+    /// it must never trigger a new projection into the user's catalog.
     pub(crate) async fn reconcile_codex_owned_projection_on_startup(&self) -> Result<bool, String> {
+        let takeover_config = self
+            .db
+            .get_proxy_config_for_app(AppType::Codex.as_str())
+            .await
+            .map_err(|e| format!("读取 Codex 启动接管状态失败: {e}"))?;
+        if !takeover_config.enabled {
+            log::debug!("Codex 接管未启用，跳过启动时自有模型目录对账");
+            return Ok(false);
+        }
+
         let live_config = self.read_codex_live()?;
         let config_text = live_config
             .get("config")
@@ -5971,7 +5982,7 @@ wire_api = "responses"
 
     #[tokio::test]
     #[serial]
-    async fn codex_startup_reconciles_owned_catalog_when_takeover_flag_drifted() {
+    async fn codex_startup_skips_owned_catalog_when_takeover_disabled() {
         let _home = TempHome::new();
         crate::settings::reload_settings().expect("reload settings");
         let db = Arc::new(Database::memory().expect("init db"));
@@ -6014,6 +6025,10 @@ wire_api = "responses"
         db.update_proxy_config_for_app(proxy_config)
             .await
             .expect("simulate drifted takeover flag");
+        service
+            .stop()
+            .await
+            .expect("stop proxy to simulate disabled local hosting");
 
         let catalog_path = crate::codex_config::get_codex_model_catalog_path();
         let mut stale_catalog: Value =
@@ -6029,10 +6044,10 @@ wire_api = "responses"
         crate::config::write_json_file(&catalog_path, &stale_catalog)
             .expect("seed stale generated catalog");
 
-        assert!(service
+        assert!(!service
             .reconcile_codex_owned_projection_on_startup()
             .await
-            .expect("reconcile owned startup projection"));
+            .expect("skip owned startup projection when takeover is disabled"));
         let refreshed: Value =
             crate::config::read_json_file(&catalog_path).expect("read refreshed catalog");
         let qwen = refreshed["models"]
@@ -6041,8 +6056,8 @@ wire_api = "responses"
             .iter()
             .find(|entry| entry["slug"] == "qwen3.8")
             .expect("Qwen entry");
-        assert_eq!(qwen["supports_image_detail_original"], true);
-        assert_eq!(qwen["supportsImageDetailOriginal"], true);
+        assert_eq!(qwen["supports_image_detail_original"], false);
+        assert_eq!(qwen["supportsImageDetailOriginal"], false);
     }
 
     #[tokio::test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CCSwitchMulti",
-  "version": "3.19.2-18",
+    "version": "3.19.2-18.7",
   "identifier": "com.ccswitchmulti.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## 变更摘要

修复 Codex 启动时模型目录投影的所有权判断：关闭 Codex 接管后，残留的 `model_catalog_json` 指针不再触发启动重生成，用户手动隐藏的模型不会被 CCSwitchMulti 覆盖。

## 关键改动

- 启动对账先读取 `proxy_config.codex.enabled`；未开启接管时直接跳过。
- 保留接管开启时的自有模型目录刷新行为。
- 增加“接管关闭 + 残留目录指针”回归测试。
- 版本更新为 `3.19.2-18.7`，补充中文发布说明和 TDD 记录。

## 验证结果

- Rust Codex 相关测试：37 passed
- `pnpm test:unit`：148 个测试文件、1213 个测试通过
- `pnpm typecheck`：通过
- `cargo fmt --check`：通过
- `git diff --check`：通过

## 风险与回滚

本改动只收紧启动时模型目录投影的触发条件，不改变接管已开启时的投影逻辑。若需要回滚，可回退本 PR 的单个提交。

## 关联 Issue

Fixes #82