### PR TITLE
feat: 环境变量自动注入（总开关 + 按 CLI 独立开关）

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -274,7 +274,7 @@ fn write_codex_live_atomic_locked(
     };
     // 准备写入内容
     let cfg_text = match config_text_opt {
-        Some(s) => normalize_codex_config_text_for_live_read(s)?,
+        Some(s) => with_codex_env_injection(&normalize_codex_config_text_for_live_read(s)?)?,
         None => String::new(),
     };
     if !cfg_text.trim().is_empty() {
@@ -528,10 +528,35 @@ fn codex_live_write_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// 把全局环境变量注入补进即将落盘的 Codex `config.toml` 文本。
+///
+/// 之所以放在最底层而不是各个供应商切换入口：Codex 有若干条会**整体重写**
+/// `config.toml` 的路径（例如本地代理接管），只在上层注入会在这些路径上被
+/// 抹掉。放在这里可以保证任何一次落盘都带上注入结果。
+///
+/// 空文本不注入——那代表调用方要清空/删除配置，不该凭空造出内容。
+///
+/// 注入失败时**降级为原样返回**：环境变量注入是增强功能，任何一次解析失败
+/// 都不应该让原本正常的供应商切换失败。
+fn with_codex_env_injection(config_text: &str) -> Result<String, AppError> {
+    if config_text.trim().is_empty() {
+        return Ok(config_text.to_string());
+    }
+    match crate::env_injection::inject_into_codex_live(config_text) {
+        Ok(text) => Ok(text),
+        Err(error) => {
+            log::warn!("注入 Codex 环境变量失败，本次写入保持原样: {error}");
+            Ok(config_text.to_string())
+        }
+    }
+}
+
 fn write_codex_live_config_atomic_locked(config_text_opt: Option<&str>) -> Result<(), AppError> {
     let config_path = get_codex_config_path();
     let cfg_text = match config_text_opt {
-        Some(config_text) => normalize_codex_config_text_for_live_read(config_text)?,
+        Some(config_text) => {
+            with_codex_env_injection(&normalize_codex_config_text_for_live_read(config_text)?)?
+        }
         None => String::new(),
     };
 
@@ -604,7 +629,8 @@ where
             AppError::Config(format!("Codex config.toml is not valid UTF-8: {error}"))
         })?;
         let normalized_before = normalize_codex_config_text_for_live_read(&before_text)?;
-        let candidate = normalize_codex_config_text_for_live_read(&build(&normalized_before)?)?;
+        let built = with_codex_env_injection(&build(&normalized_before)?)?;
+        let candidate = normalize_codex_config_text_for_live_read(&built)?;
         if !candidate.trim().is_empty() {
             toml::from_str::<toml::Table>(&candidate)
                 .map_err(|error| AppError::toml(&config_path, error))?;
@@ -658,7 +684,8 @@ where
             AppError::Config(format!("Codex config.toml is not valid UTF-8: {error}"))
         })?;
         let normalized_before = normalize_codex_config_text_for_live_read(&before_text)?;
-        let candidate = normalize_codex_config_text_for_live_read(&build(&normalized_before)?)?;
+        let built = with_codex_env_injection(&build(&normalized_before)?)?;
+        let candidate = normalize_codex_config_text_for_live_read(&built)?;
         if !candidate.trim().is_empty() {
             toml::from_str::<toml::Table>(&candidate)
                 .map_err(|error| AppError::toml(&config_path, error))?;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -841,3 +841,13 @@ pub async fn open_log_dir(app: AppHandle) -> Result<bool, String> {
 
     Ok(true)
 }
+
+/// 检查环境变量注入是否存在已知的失效风险。
+///
+/// 目前只有一种：Codex 的 `[shell_environment_policy] include_only`
+/// allowlist 会过滤掉 `set` 里恢复出来的值，此时注入不生效。
+#[tauri::command]
+pub async fn inspect_env_injection_conflicts(
+) -> Result<crate::env_injection::EnvInjectionConflicts, String> {
+    Ok(crate::env_injection::inspect_conflicts())
+}

--- a/src-tauri/src/env_injection.rs
+++ b/src-tauri/src/env_injection.rs
@@ -1,0 +1,437 @@
+//! 环境变量自动注入。
+//!
+//! 把用户在设置里配置的变量写进各 CLI **自己的配置文件**，从而在不改系统
+//! 环境、不启用本地代理的前提下，让 CLI 以指定的环境变量运行。
+//!
+//! 之所以坚持走 CLI 官方配置而不是 shell rc 或 PATH shim：
+//! - shell rc 里的 `export` 是全局的，会污染所有进程，与「只影响这一个
+//!   CLI」的目标相悖；
+//! - shim 需要改 PATH，侵入性强且容易被 CLI 自更新破坏；
+//! - 写进 CLI 自己的配置后，**用户不启用本地代理、直连官方**时同样生效，
+//!   因为 CLI 每次启动都会读自己的配置文件。
+//!
+//! 各 CLI 的官方依据与能力边界：
+//! - Claude Code：`~/.claude/settings.json` 的 `env` 对象。官方文档明确
+//!   「Claude Code 在启动时直接从文件读取它们，因此无论如何启动 claude，
+//!   它们都会生效」——作用于主进程与其子进程。
+//! - Codex CLI：`~/.codex/config.toml` 的 `[shell_environment_policy] set`。
+//!   官方文档说明该节控制的是「Codex 传给其所派生子进程的环境变量」，
+//!   **不含 Codex 主进程自身**。对「让 agent 执行的命令看到某个时区」够用，
+//!   但不改变 Codex 主进程自己的行为。
+//! - Gemini CLI：官方 `settings.json` 没有进程级 env 字段（只有
+//!   `mcpServers.*.env`，且值仅支持 `$VAR` 引用展开），因此**不支持**，
+//!   不提供该目标，避免给出「开关开了但没效果」的错觉。
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+use toml_edit::{DocumentMut, Item, Table};
+
+use crate::config::{get_claude_settings_path, read_json_file, write_json_file};
+use crate::error::AppError;
+use crate::settings::{EnvInjectionSettings, EnvInjectionTarget};
+
+/// 把变量合并进 Claude settings.json 的 `env` 对象。
+///
+/// **只补缺、不覆盖**：provider `settings_config.env` 里已有的同名键一律保留，
+/// 避免全局变量意外顶掉 `ANTHROPIC_BASE_URL` 之类路由变量而打乱供应商切换。
+pub fn merge_into_claude_settings(settings: &mut Value, vars: &BTreeMap<String, String>) {
+    if vars.is_empty() {
+        return;
+    }
+    let Some(obj) = settings.as_object_mut() else {
+        return;
+    };
+    let env = obj
+        .entry("env")
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Some(env_map) = env.as_object_mut() else {
+        // 用户把 env 写成了非对象类型，交给用户自己处理，不覆盖
+        log::warn!("Claude settings.json 的 env 不是对象，跳过环境变量注入");
+        return;
+    };
+    for (key, value) in vars {
+        if !env_map.contains_key(key) {
+            env_map.insert(key.clone(), Value::String(value.clone()));
+        }
+    }
+}
+
+/// 从 Claude settings.json 的 `env` 中移除注入的变量。
+///
+/// **只删值完全匹配的条目**——用户如果自己改过值，说明那已经是他的配置，
+/// 不再由本功能托管。
+pub fn remove_from_claude_settings(settings: &mut Value, vars: &BTreeMap<String, String>) {
+    if vars.is_empty() {
+        return;
+    }
+    let Some(obj) = settings.as_object_mut() else {
+        return;
+    };
+    let Some(env_map) = obj.get_mut("env").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for (key, value) in vars {
+        let injected = env_map.get(key).and_then(Value::as_str) == Some(value.as_str());
+        if injected {
+            env_map.remove(key);
+        }
+    }
+}
+
+/// Codex `config.toml` 是否配置了 include 型 allowlist。
+///
+/// 官方文档写明 include 模式的 allowlist 会过滤掉 `set` 恢复出来的值
+/// （"An include-pattern allowlist can still remove that restored value"），
+/// 一旦存在，注入的变量可能不生效，需要在 UI 上提示。
+pub fn codex_env_policy_has_include_allowlist(config_text: &str) -> bool {
+    let Ok(doc) = config_text.parse::<DocumentMut>() else {
+        return false;
+    };
+    doc.get("shell_environment_policy")
+        .and_then(Item::as_table)
+        .and_then(|table| table.get("include_only"))
+        .and_then(Item::as_array)
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false)
+}
+
+/// 把变量写入 Codex `config.toml` 的 `[shell_environment_policy] set`。
+///
+/// 同样遵循「只补缺、不覆盖」。
+pub fn merge_into_codex_config_text(
+    config_text: &str,
+    vars: &BTreeMap<String, String>,
+) -> Result<String, AppError> {
+    if vars.is_empty() {
+        return Ok(config_text.to_string());
+    }
+    let mut doc = config_text.parse::<DocumentMut>().map_err(|error| {
+        AppError::Config(format!(
+            "Codex config.toml 解析失败，无法注入环境变量: {error}"
+        ))
+    })?;
+
+    {
+        let policy_item = doc
+            .entry("shell_environment_policy")
+            .or_insert(Item::Table(Table::new()));
+        let policy_table = policy_item.as_table_mut().ok_or_else(|| {
+            AppError::Config("Codex config.toml 的 shell_environment_policy 不是表".to_string())
+        })?;
+        let set_item = policy_table
+            .entry("set")
+            .or_insert(Item::Table(Table::new()));
+        let set_table = set_item.as_table_mut().ok_or_else(|| {
+            AppError::Config("Codex config.toml 的 shell_environment_policy.set 不是表".to_string())
+        })?;
+        for (key, value) in vars {
+            if !set_table.contains_key(key) {
+                set_table.insert(key, toml_edit::value(value.as_str()));
+            }
+        }
+    }
+
+    Ok(doc.to_string())
+}
+
+/// 从 Codex `config.toml` 的 `[shell_environment_policy] set` 中移除注入的变量。
+///
+/// 同样只删值匹配的条目。移除后若 `set` 变空会连带清掉空表，避免留下垃圾配置。
+pub fn remove_from_codex_config_text(
+    config_text: &str,
+    vars: &BTreeMap<String, String>,
+) -> Result<String, AppError> {
+    if vars.is_empty() {
+        return Ok(config_text.to_string());
+    }
+    let mut doc = config_text.parse::<DocumentMut>().map_err(|error| {
+        AppError::Config(format!(
+            "Codex config.toml 解析失败，无法移除环境变量: {error}"
+        ))
+    })?;
+
+    {
+        let Some(policy_table) = doc
+            .get_mut("shell_environment_policy")
+            .and_then(Item::as_table_mut)
+        else {
+            return Ok(config_text.to_string());
+        };
+        let Some(set_table) = policy_table.get_mut("set").and_then(Item::as_table_mut) else {
+            return Ok(config_text.to_string());
+        };
+        for (key, value) in vars {
+            let injected = set_table.get(key).and_then(Item::as_str) == Some(value.as_str());
+            if injected {
+                set_table.remove(key);
+            }
+        }
+    }
+
+    // `set` 被清空后连带清理空表，避免留下垃圾配置
+    let set_now_empty = doc
+        .get("shell_environment_policy")
+        .and_then(Item::as_table)
+        .and_then(|table| table.get("set"))
+        .and_then(Item::as_table)
+        .is_some_and(toml_edit::Table::is_empty);
+
+    if set_now_empty {
+        if let Some(policy_table) = doc
+            .get_mut("shell_environment_policy")
+            .and_then(Item::as_table_mut)
+        {
+            policy_table.remove("set");
+        }
+    }
+
+    Ok(doc.to_string())
+}
+
+/// 对 Claude live 配置做一次「移除旧的 + 注入新的」。
+fn apply_claude(
+    previous: &EnvInjectionSettings,
+    next: &EnvInjectionSettings,
+) -> Result<(), AppError> {
+    let previous_vars = previous.variables_for(EnvInjectionTarget::Claude);
+    let next_vars = next.variables_for(EnvInjectionTarget::Claude);
+    if previous_vars.is_empty() && next_vars.is_empty() {
+        return Ok(());
+    }
+
+    let path = get_claude_settings_path();
+    // 文件不存在且这次没有要注入的内容时，不做任何事（不要凭空创建配置）
+    if !path.exists() && next_vars.is_empty() {
+        return Ok(());
+    }
+
+    let mut settings: Value = if path.exists() {
+        read_json_file::<Value>(&path).unwrap_or_else(|error| {
+            log::warn!("读取 Claude settings.json 失败，按空配置处理: {error}");
+            Value::Object(Map::new())
+        })
+    } else {
+        Value::Object(Map::new())
+    };
+
+    remove_from_claude_settings(&mut settings, &previous_vars);
+    merge_into_claude_settings(&mut settings, &next_vars);
+    write_json_file(&path, &settings)?;
+    log::info!("已把环境变量注入同步到 Claude settings.json");
+    Ok(())
+}
+
+/// 对 Codex live 配置做一次「移除旧的 + 注入新的」。
+fn apply_codex(
+    previous: &EnvInjectionSettings,
+    next: &EnvInjectionSettings,
+) -> Result<(), AppError> {
+    let previous_vars = previous.variables_for(EnvInjectionTarget::Codex);
+    let next_vars = next.variables_for(EnvInjectionTarget::Codex);
+    if previous_vars.is_empty() && next_vars.is_empty() {
+        return Ok(());
+    }
+
+    crate::codex_config::reconcile_codex_live_config_atomic(|live| {
+        let cleaned = remove_from_codex_config_text(live, &previous_vars)?;
+        merge_into_codex_config_text(&cleaned, &next_vars)
+    })?;
+    log::info!("已把环境变量注入同步到 Codex config.toml");
+    Ok(())
+}
+
+/// 开关或变量发生变化后，把注入结果同步到所有支持的 CLI 配置。
+///
+/// 只处理 Claude 与 Codex；Gemini 官方配置没有对应的写入位置。
+/// 调用方应忽略返回值里的失败——设置本身已经存盘，不该因为某
+/// 一个 CLI 的配置写不动就回滚用户的设置。
+pub fn sync_to_live_configs(
+    previous: &EnvInjectionSettings,
+    next: &EnvInjectionSettings,
+) -> Result<(), AppError> {
+    let mut first_error: Option<AppError> = None;
+
+    if let Err(error) = apply_claude(previous, next) {
+        log::warn!("同步环境变量注入到 Claude 失败: {error}");
+        first_error.get_or_insert(error);
+    }
+    if let Err(error) = apply_codex(previous, next) {
+        log::warn!("同步环境变量注入到 Codex 失败: {error}");
+        first_error.get_or_insert(error);
+    }
+
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+/// 供应商切换写 live 配置时调用：把当前注入的变量补进即将写入的内容。
+///
+/// Claude 走这条路径，因为 `live.rs` 写 settings.json 前会构造完整对象。
+pub fn inject_into_claude_live(settings: &mut Value) {
+    let current = crate::settings::get_settings();
+    merge_into_claude_settings(
+        settings,
+        &current
+            .env_injection
+            .variables_for(EnvInjectionTarget::Claude),
+    );
+}
+
+/// 把注入过的变量从 Claude settings.json 中摘掉。
+///
+/// 用于「写 live 配置后再读回、存进供应商记录」的场景：注入是全局的、由设置
+/// 单独管理，不能被固化进某一条供应商记录——否则关掉开关后残留值会跟着该
+/// 供应商到处跑，还会污染备份与云同步。
+pub fn strip_from_claude_settings(settings: &mut Value) {
+    let vars = crate::settings::get_settings()
+        .env_injection
+        .variables_for(EnvInjectionTarget::Claude);
+    remove_from_claude_settings(settings, &vars);
+}
+
+/// 当前 live 配置里已知的、会让注入失效的冲突。
+///
+/// 前端据此给出提示，避免用户看到「开关开了但没效果」却不知道原因。
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvInjectionConflicts {
+    /// Codex 配了 include 型 allowlist，官方会用它过滤掉 `set` 恢复出来的值，
+    /// 此时注入的变量不会生效。
+    pub codex_include_allowlist: bool,
+}
+
+/// 读取当前 live 配置，检查是否存在会让注入失效的冲突。
+///
+/// 只读，失败一律按「没有冲突」处理——这只是提示信息，不该阻塞 UI。
+pub fn inspect_conflicts() -> EnvInjectionConflicts {
+    let codex_include_allowlist = crate::codex_config::read_codex_config_text()
+        .inspect_err(|error| {
+            log::debug!("读取 Codex config.toml 失败，跳过注入冲突检查: {error}");
+        })
+        .is_ok_and(|text| {
+            let conflict = codex_env_policy_has_include_allowlist(&text);
+            if conflict {
+                log::warn!(
+                    "Codex config.toml 存在 shell_environment_policy.include_only，\
+                     注入的环境变量可能不会生效"
+                );
+            }
+            conflict
+        });
+
+    EnvInjectionConflicts {
+        codex_include_allowlist,
+    }
+}
+
+/// 供应商切换写 live 配置时调用：把当前注入的变量补进即将写入的 TOML 文本。
+pub fn inject_into_codex_live(config_text: &str) -> Result<String, AppError> {
+    let current = crate::settings::get_settings();
+    merge_into_codex_config_text(
+        config_text,
+        &current
+            .env_injection
+            .variables_for(EnvInjectionTarget::Codex),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn claude_merge_does_not_overwrite_existing_keys() {
+        let mut settings = serde_json::json!({
+            "env": { "ANTHROPIC_BASE_URL": "https://provider.example" }
+        });
+        merge_into_claude_settings(
+            &mut settings,
+            &vars(&[
+                ("TZ", "Asia/Shanghai"),
+                ("ANTHROPIC_BASE_URL", "https://evil.example"),
+            ]),
+        );
+        let env = settings["env"].as_object().unwrap();
+        assert_eq!(env["TZ"], "Asia/Shanghai");
+        // provider 的路由变量绝不能被顶掉
+        assert_eq!(env["ANTHROPIC_BASE_URL"], "https://provider.example");
+    }
+
+    #[test]
+    fn claude_remove_only_touches_matching_values() {
+        let mut settings = serde_json::json!({
+            "env": { "TZ": "Asia/Shanghai", "KEEP": "user-value" }
+        });
+        remove_from_claude_settings(
+            &mut settings,
+            &vars(&[("TZ", "Asia/Shanghai"), ("KEEP", "injected-value")]),
+        );
+        let env = settings["env"].as_object().unwrap();
+        assert!(env.get("TZ").is_none());
+        // 值不匹配说明是用户自己的配置，必须保留
+        assert_eq!(env["KEEP"], "user-value");
+    }
+
+    #[test]
+    fn codex_merge_writes_shell_environment_policy_set() {
+        let merged =
+            merge_into_codex_config_text("model = \"gpt-5\"\n", &vars(&[("TZ", "Asia/Shanghai")]))
+                .unwrap();
+        assert!(merged.contains("[shell_environment_policy.set]"));
+        assert!(merged.contains("TZ = \"Asia/Shanghai\""));
+        // 原有内容必须保留
+        assert!(merged.contains("model = \"gpt-5\""));
+        // 结果必须是合法 TOML
+        merged.parse::<DocumentMut>().unwrap();
+    }
+
+    #[test]
+    fn codex_merge_does_not_overwrite_existing_values() {
+        let base = "[shell_environment_policy.set]\nTZ = \"UTC\"\n";
+        let merged = merge_into_codex_config_text(base, &vars(&[("TZ", "Asia/Shanghai")])).unwrap();
+        assert!(merged.contains("TZ = \"UTC\""));
+        assert!(!merged.contains("Asia/Shanghai"));
+    }
+
+    #[test]
+    fn codex_remove_drops_empty_set_table() {
+        let base = "model = \"gpt-5\"\n\n[shell_environment_policy.set]\nTZ = \"Asia/Shanghai\"\n";
+        let cleaned =
+            remove_from_codex_config_text(base, &vars(&[("TZ", "Asia/Shanghai")])).unwrap();
+        assert!(!cleaned.contains("Asia/Shanghai"));
+        assert!(!cleaned.contains("shell_environment_policy"));
+        assert!(cleaned.contains("model = \"gpt-5\""));
+    }
+
+    #[test]
+    fn codex_detects_include_allowlist_conflict() {
+        let with_allowlist = "[shell_environment_policy]\ninclude_only = [\"PATH\", \"HOME\"]\n";
+        assert!(codex_env_policy_has_include_allowlist(with_allowlist));
+        assert!(!codex_env_policy_has_include_allowlist(
+            "[shell_environment_policy.set]\nTZ = \"UTC\"\n"
+        ));
+    }
+
+    #[test]
+    fn empty_variables_leave_config_untouched() {
+        let base = "model = \"gpt-5\"\n";
+        assert_eq!(
+            merge_into_codex_config_text(base, &BTreeMap::new()).unwrap(),
+            base
+        );
+        let mut settings = serde_json::json!({ "env": {} });
+        merge_into_claude_settings(&mut settings, &BTreeMap::new());
+        assert_eq!(settings, serde_json::json!({ "env": {} }));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod commands;
 mod config;
 mod database;
 mod deeplink;
+mod env_injection;
 mod error;
 mod gemini_config;
 mod gemini_mcp;
@@ -1516,6 +1517,7 @@ pub fn run() {
             codex_config::get_codex_subagent_profile_statuses,
             codex_config::preview_codex_subagent_profile,
             commands::save_settings,
+            commands::inspect_env_injection_conflicts,
             commands::has_codex_unify_history_backup,
             commands::restore_codex_unified_history,
             commands::get_rectifier_config,

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -230,13 +230,18 @@ impl ConfigService {
             fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
         }
 
-        let settings = sanitize_claude_settings_for_live(&provider.settings_config);
+        let mut settings = sanitize_claude_settings_for_live(&provider.settings_config);
+        crate::env_injection::inject_into_claude_live(&mut settings);
         write_json_file(&settings_path, &settings)?;
 
         let live_after = read_json_file::<serde_json::Value>(&settings_path)?;
+        // 回写进供应商记录前把注入的变量摘掉：注入是全局的、由设置单独管理，
+        // 不该被固化到某一条供应商记录里。
+        let mut stored = live_after;
+        crate::env_injection::strip_from_claude_settings(&mut stored);
         if let Some(manager) = config.get_manager_mut(&AppType::Claude) {
             if let Some(target) = manager.providers.get_mut(provider_id) {
-                target.settings_config = live_after;
+                target.settings_config = stored;
             }
         }
 

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1178,7 +1178,10 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
     match app_type {
         AppType::Claude => {
             let path = get_claude_settings_path();
-            let settings = sanitize_claude_settings_for_live(&provider.settings_config);
+            let mut settings = sanitize_claude_settings_for_live(&provider.settings_config);
+            // 供应商切换会整体重写 settings.json，必须在这里补回全局注入的变量，
+            // 否则用户切换一次供应商后注入就失效了。
+            crate::env_injection::inject_into_claude_live(&mut settings);
             write_json_file(&path, &settings)?;
         }
         AppType::ClaudeDesktop => {

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3958,7 +3958,8 @@ impl ProxyService {
 
     fn write_claude_live(&self, config: &Value) -> Result<(), String> {
         let path = get_claude_settings_path();
-        let settings = crate::services::provider::sanitize_claude_settings_for_live(config);
+        let mut settings = crate::services::provider::sanitize_claude_settings_for_live(config);
+        crate::env_injection::inject_into_claude_live(&mut settings);
         write_json_file(&path, &settings).map_err(|e| format!("写入 Claude 配置失败: {e}"))
     }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{OnceLock, RwLock};
@@ -407,6 +408,98 @@ pub struct CodexOfficialHistoryUnifyMigration {
     pub codex_config_dir: Option<String>,
 }
 
+/// 环境变量自动注入的目标 CLI。
+///
+/// 只有官方配置原生支持进程级（或子进程级）env 声明的 CLI 才在列。
+/// Gemini CLI 的 `settings.json` 没有等价字段，因此不提供该目标。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum EnvInjectionTarget {
+    Claude,
+    Codex,
+}
+
+/// 环境变量自动注入的目标开关。
+///
+/// 未列出的 CLI 一律视为禁用——目前 Gemini CLI 官方设置里没有可写入
+/// 进程级环境变量的字段，硬做只会得到「开关打开了但没效果」的错觉。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvInjectionTargets {
+    /// 写入 `~/.claude/settings.json` 的 `env`
+    #[serde(default = "default_true")]
+    pub claude: bool,
+    /// 写入 `~/.codex/config.toml` 的 `[shell_environment_policy] set`
+    #[serde(default = "default_true")]
+    pub codex: bool,
+}
+
+impl Default for EnvInjectionTargets {
+    fn default() -> Self {
+        Self {
+            claude: true,
+            codex: true,
+        }
+    }
+}
+
+/// 环境变量自动注入设置。
+///
+/// 动机示例：让单个 CLI 运行在指定时区（`TZ=Asia/Shanghai`）而不改系统时区。
+/// 注入只写各 CLI 自己的配置文件，因此**不启用本地代理、直连官方**时同样生效。
+///
+/// 合并语义：全局变量**只补缺、不覆盖** provider `settings_config.env`
+/// 里已存在的同名键。provider 的 env 存放路由相关变量
+/// （`ANTHROPIC_BASE_URL`、`ANTHROPIC_API_KEY` 等），一旦允许覆盖，
+/// 用户填一个同名变量就会静默打乱供应商切换。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvInjectionSettings {
+    /// 总开关。默认关闭，保证不影响任何现有行为。
+    #[serde(default)]
+    pub enabled: bool,
+    /// 按 CLI 的独立开关
+    #[serde(default)]
+    pub targets: EnvInjectionTargets,
+    /// 要注入的键值对。用 BTreeMap 保证序列化顺序稳定，
+    /// 避免 Map 顺序抖动造成配置文件无意义 diff。
+    #[serde(default)]
+    pub variables: BTreeMap<String, String>,
+}
+
+impl EnvInjectionSettings {
+    /// 该目标是否启用且至少有一个变量。
+    pub fn is_active_for(&self, target: EnvInjectionTarget) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        if self.variables.is_empty() {
+            return false;
+        }
+        match target {
+            EnvInjectionTarget::Claude => self.targets.claude,
+            EnvInjectionTarget::Codex => self.targets.codex,
+        }
+    }
+
+    /// 取该目标生效的变量集合；未启用时返回空。
+    pub fn variables_for(&self, target: EnvInjectionTarget) -> BTreeMap<String, String> {
+        if !self.is_active_for(target) {
+            return BTreeMap::new();
+        }
+        self.variables
+            .iter()
+            .filter(|(key, _)| is_valid_env_key(key))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect()
+    }
+}
+
+/// 过滤掉空键名与含 `=`/NUL 的非法键名，避免写出损坏的配置。
+pub fn is_valid_env_key(key: &str) -> bool {
+    !key.is_empty() && !key.contains('=') && !key.contains('\0') && !key.contains('\n')
+}
+
 /// 应用设置结构
 ///
 /// 存储设备级别设置，保存在本地 `~/.cc-switch/settings.json`，不随数据库同步。
@@ -572,6 +665,11 @@ pub struct AppSettings {
     #[serde(default)]
     pub quota_collaboration: QuotaCollaborationSettings,
 
+    // ===== 环境变量自动注入 =====
+    /// 注入到各 CLI 官方配置文件的环境变量（独立开关，默认关闭）
+    #[serde(default)]
+    pub env_injection: EnvInjectionSettings,
+
     // ===== 本机自动迁移状态 =====
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub local_migrations: Option<LocalMigrations>,
@@ -639,6 +737,7 @@ impl Default for AppSettings {
             backup_retain_count: None,
             preferred_terminal: None,
             quota_collaboration: QuotaCollaborationSettings::default(),
+            env_injection: EnvInjectionSettings::default(),
             local_migrations: None,
         }
     }
@@ -845,13 +944,37 @@ pub fn get_settings_for_frontend() -> AppSettings {
 
 pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
     new_settings.normalize_paths();
+
+    let previous_env_injection = settings_store()
+        .read()
+        .unwrap_or_else(|e| {
+            log::warn!("设置锁已毒化，使用恢复值: {e}");
+            e.into_inner()
+        })
+        .env_injection
+        .clone();
+    let next_env_injection = new_settings.env_injection.clone();
+
     save_settings_file(&new_settings)?;
 
-    let mut guard = settings_store().write().unwrap_or_else(|e| {
-        log::warn!("设置锁已毒化，使用恢复值: {e}");
-        e.into_inner()
-    });
-    *guard = new_settings;
+    {
+        let mut guard = settings_store().write().unwrap_or_else(|e| {
+            log::warn!("设置锁已毒化，使用恢复值: {e}");
+            e.into_inner()
+        });
+        *guard = new_settings;
+    }
+
+    // 必须在释放设置锁之后再同步：同步过程会读取 live 配置并可能回调
+    // get_settings()，RwLock 不可重入，持锁调用会死锁。
+    if previous_env_injection != next_env_injection {
+        if let Err(error) =
+            crate::env_injection::sync_to_live_configs(&previous_env_injection, &next_env_injection)
+        {
+            // 设置本身已经存盘，不因为某一个 CLI 配置写不动就回滚用户设置
+            log::warn!("设置已保存，但同步环境变量注入到 CLI 配置失败: {error}");
+        }
+    }
     Ok(())
 }
 

--- a/src/components/settings/EnvInjectionSettings.tsx
+++ b/src/components/settings/EnvInjectionSettings.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AlertTriangle, Plus, Trash2, Variable } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ToggleRow } from "@/components/ui/toggle-row";
+import { settingsApi } from "@/lib/api/settings";
+import type {
+  EnvInjectionConflicts,
+  EnvInjectionSettings as EnvInjectionSettingsValue,
+} from "@/types";
+
+export interface EnvInjectionSettingsProps {
+  value?: EnvInjectionSettingsValue;
+  onChange: (value: EnvInjectionSettingsValue) => void;
+}
+
+interface EnvRow {
+  id: string;
+  key: string;
+  value: string;
+}
+
+/**
+ * 键名不能为空、不能含 `=`、NUL 或换行，否则会写出损坏的配置。
+ * 后端 `is_valid_env_key` 有同样一套校验，这里提前拦一次给即时反馈。
+ */
+const isValidKey = (key: string) =>
+  key.length > 0 &&
+  !key.includes("=") &&
+  !key.includes("\u0000") &&
+  !key.includes("\n");
+
+const toRows = (variables: Record<string, string>): EnvRow[] =>
+  Object.entries(variables).map(([key, value], index) => ({
+    id: `${index}-${key}`,
+    key,
+    value,
+  }));
+
+const rowsToVariables = (rows: EnvRow[]): Record<string, string> => {
+  const variables: Record<string, string> = {};
+  for (const row of rows) {
+    const key = row.key.trim();
+    if (!isValidKey(key)) continue;
+    variables[key] = row.value;
+  }
+  return variables;
+};
+
+export function EnvInjectionSettings({
+  value,
+  onChange,
+}: EnvInjectionSettingsProps) {
+  const { t } = useTranslation();
+
+  const normalized = useMemo<EnvInjectionSettingsValue>(
+    () => ({
+      enabled: value?.enabled ?? false,
+      targets: {
+        claude: value?.targets?.claude ?? true,
+        codex: value?.targets?.codex ?? true,
+      },
+      variables: value?.variables ?? {},
+    }),
+    [value],
+  );
+
+  const [rows, setRows] = useState<EnvRow[]>(() =>
+    toRows(normalized.variables),
+  );
+  const [draftKey, setDraftKey] = useState("");
+  const [draftValue, setDraftValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [conflicts, setConflicts] = useState<EnvInjectionConflicts | null>(
+    null,
+  );
+
+  // 外部改动（配置导入、云同步、重置）后重新对齐本地草稿。
+  // 用序列化后的签名做依赖，避免对象引用变化导致每轮渲染都重置输入框。
+  const variablesSignature = JSON.stringify(normalized.variables);
+  useEffect(() => {
+    setRows(toRows(JSON.parse(variablesSignature) as Record<string, string>));
+  }, [variablesSignature]);
+
+  // 冲突只读提示，失败就当没有冲突，不阻塞 UI
+  useEffect(() => {
+    if (!normalized.enabled) {
+      setConflicts(null);
+      return;
+    }
+    let cancelled = false;
+    void settingsApi.inspectEnvInjectionConflicts().then((result) => {
+      if (!cancelled) setConflicts(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [normalized.enabled, variablesSignature]);
+
+  const commit = (nextRows: EnvRow[]) => {
+    setRows(nextRows);
+    onChange({ ...normalized, variables: rowsToVariables(nextRows) });
+  };
+
+  const updateRow = (id: string, patch: Partial<EnvRow>) => {
+    setRows((current) =>
+      current.map((row) => (row.id === id ? { ...row, ...patch } : row)),
+    );
+  };
+
+  const removeRow = (id: string) => {
+    commit(rows.filter((row) => row.id !== id));
+  };
+
+  const addRow = () => {
+    const key = draftKey.trim();
+    if (!isValidKey(key)) {
+      setError(t("settings.envInjection.invalidKey"));
+      return;
+    }
+    if (rows.some((row) => row.key.trim() === key)) {
+      setError(t("settings.envInjection.duplicateKey"));
+      return;
+    }
+    setError(null);
+    setDraftKey("");
+    setDraftValue("");
+    commit([...rows, { id: `${Date.now()}-${key}`, key, value: draftValue }]);
+  };
+
+  const setEnabled = (enabled: boolean) => {
+    setError(null);
+    onChange({ ...normalized, enabled });
+  };
+
+  const setTarget = (target: "claude" | "codex", checked: boolean) => {
+    onChange({
+      ...normalized,
+      targets: { ...normalized.targets, [target]: checked },
+    });
+  };
+
+  return (
+    <section className="space-y-4">
+      <header className="space-y-1">
+        <h3 className="text-sm font-medium">
+          {t("settings.envInjection.title")}
+        </h3>
+        <p className="text-xs text-muted-foreground">
+          {t("settings.envInjection.description")}
+        </p>
+      </header>
+
+      <ToggleRow
+        icon={<Variable className="h-4 w-4 text-violet-500" />}
+        title={t("settings.envInjection.enable")}
+        description={t("settings.envInjection.enableDescription")}
+        checked={normalized.enabled}
+        onCheckedChange={setEnabled}
+      />
+
+      {normalized.enabled ? (
+        <div className="space-y-4 rounded-xl border border-border bg-card/50 p-4">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">
+              {t("settings.envInjection.targets")}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {t("settings.envInjection.targetsDescription")}
+            </p>
+            <div className="flex flex-wrap gap-1">
+              <TargetButton
+                active={normalized.targets.claude}
+                onClick={() => setTarget("claude", !normalized.targets.claude)}
+              >
+                {t("settings.envInjection.claude")}
+              </TargetButton>
+              <TargetButton
+                active={normalized.targets.codex}
+                onClick={() => setTarget("codex", !normalized.targets.codex)}
+              >
+                {t("settings.envInjection.codex")}
+              </TargetButton>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t("settings.envInjection.geminiUnsupported")}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm font-medium">
+              {t("settings.envInjection.variables")}
+            </p>
+
+            {rows.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                {t("settings.envInjection.empty")}
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {rows.map((row) => (
+                  <div key={row.id} className="flex items-center gap-2">
+                    <Input
+                      value={row.key}
+                      aria-label={t("settings.envInjection.keyPlaceholder")}
+                      placeholder={t("settings.envInjection.keyPlaceholder")}
+                      className="h-8 flex-[2] font-mono text-xs"
+                      onChange={(event) =>
+                        updateRow(row.id, { key: event.target.value })
+                      }
+                      onBlur={() => commit(rows)}
+                    />
+                    <Input
+                      value={row.value}
+                      aria-label={t("settings.envInjection.valuePlaceholder")}
+                      placeholder={t("settings.envInjection.valuePlaceholder")}
+                      className="h-8 flex-[3] font-mono text-xs"
+                      onChange={(event) =>
+                        updateRow(row.id, { value: event.target.value })
+                      }
+                      onBlur={() => commit(rows)}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                      aria-label={t("common.delete")}
+                      onClick={() => removeRow(row.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="flex items-center gap-2">
+              <Input
+                value={draftKey}
+                aria-label={t("settings.envInjection.keyPlaceholder")}
+                placeholder={t("settings.envInjection.keyPlaceholder")}
+                className="h-8 flex-[2] font-mono text-xs"
+                onChange={(event) => setDraftKey(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") addRow();
+                }}
+              />
+              <Input
+                value={draftValue}
+                aria-label={t("settings.envInjection.valuePlaceholder")}
+                placeholder={t("settings.envInjection.valuePlaceholder")}
+                className="h-8 flex-[3] font-mono text-xs"
+                onChange={(event) => setDraftValue(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") addRow();
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-8 w-8 shrink-0"
+                aria-label={t("settings.envInjection.add")}
+                onClick={addRow}
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+
+            {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            {t("settings.envInjection.mergeHint")}
+          </p>
+
+          {conflicts?.codexIncludeAllowlist ? (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                {t("settings.envInjection.codexIncludeAllowlistWarning")}
+              </span>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+interface TargetButtonProps {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function TargetButton({ active, onClick, children }: TargetButtonProps) {
+  return (
+    <Button
+      type="button"
+      onClick={onClick}
+      size="sm"
+      variant={active ? "default" : "ghost"}
+      className={
+        active
+          ? "min-w-[110px] shadow-sm"
+          : "min-w-[110px] text-muted-foreground hover:bg-muted hover:text-foreground"
+      }
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -41,6 +41,7 @@ import { WindowSettings } from "@/components/settings/WindowSettings";
 import { AppVisibilitySettings } from "@/components/settings/AppVisibilitySettings";
 import { SkillStorageLocationSettings } from "@/components/settings/SkillStorageLocationSettings";
 import { SkillSyncMethodSettings } from "@/components/settings/SkillSyncMethodSettings";
+import { EnvInjectionSettings } from "@/components/settings/EnvInjectionSettings";
 import { TerminalSettings } from "@/components/settings/TerminalSettings";
 import { DirectorySettings } from "@/components/settings/DirectorySettings";
 import { ImportExportSection } from "@/components/settings/ImportExportSection";
@@ -288,6 +289,12 @@ export function SettingsPage({
                       value={settings.preferredTerminal}
                       onChange={(terminal) =>
                         handleAutoSave({ preferredTerminal: terminal })
+                      }
+                    />
+                    <EnvInjectionSettings
+                      value={settings.envInjection}
+                      onChange={(envInjection) =>
+                        handleAutoSave({ envInjection })
                       }
                     />
                   </motion.div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -759,6 +759,26 @@
       "copy": "Copy Files",
       "symlinkHint": "Symlinks save disk space and enable real-time sync. Note: May require admin privileges or Developer Mode on Windows"
     },
+    "envInjection": {
+      "title": "Environment Variable Injection",
+      "description": "Write variables into each CLI's own config file — no system-wide changes, no local proxy required.",
+      "enable": "Enable environment variable injection",
+      "enableDescription": "When disabled, CCSwitchMulti writes no variables into any CLI config.",
+      "targets": "Targets",
+      "targetsDescription": "Toggle each CLI independently.",
+      "claude": "Claude Code",
+      "codex": "Codex",
+      "geminiUnsupported": "Gemini CLI has no process-level env field in its official settings, so injection is not supported.",
+      "variables": "Variables",
+      "empty": "No variables yet. Add one and it will be written to the target CLI config on save.",
+      "keyPlaceholder": "Name",
+      "valuePlaceholder": "Value",
+      "add": "Add variable",
+      "invalidKey": "Name cannot be empty and must not contain '=', newlines, or NUL.",
+      "duplicateKey": "That variable name already exists.",
+      "mergeHint": "Fill gaps only, never overwrite: variables already set by a provider (e.g. ANTHROPIC_BASE_URL) keep their value, so provider switching is not disturbed.",
+      "codexIncludeAllowlistWarning": "Codex is configured with a shell_environment_policy.include_only allowlist. Codex filters injected variables through it, so injection may not take effect for Codex."
+    },
     "terminal": {
       "title": "Preferred Terminal",
       "description": "Choose which terminal app to use when clicking the terminal button",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -756,6 +756,26 @@
       "copy": "ファイルコピー",
       "symlinkHint": "シンボリックリンクはディスク容量を節約し、リアルタイム同期を有効にします。注意：Windowsでは管理者権限または開発者モードが必要な場合があります"
     },
+    "envInjection": {
+      "title": "環境変数の注入",
+      "description": "各 CLI 自身の設定ファイルに変数を書き込みます。システム環境の変更もローカルプロキシも不要です。",
+      "enable": "環境変数の注入を有効にする",
+      "enableDescription": "無効の場合、CCSwitchMulti はどの CLI 設定にも変数を書き込みません。",
+      "targets": "対象",
+      "targetsDescription": "CLI ごとに個別に切り替えられます。",
+      "claude": "Claude Code",
+      "codex": "Codex",
+      "geminiUnsupported": "Gemini CLI の公式設定にはプロセスレベルの環境変数項目がないため、注入はサポートされません。",
+      "variables": "変数",
+      "empty": "まだ変数がありません。追加して保存すると対象 CLI の設定に書き込まれます。",
+      "keyPlaceholder": "変数名",
+      "valuePlaceholder": "値",
+      "add": "変数を追加",
+      "invalidKey": "変数名は空にできず、'='・改行・NUL を含められません。",
+      "duplicateKey": "その変数名は既に存在します。",
+      "mergeHint": "不足分のみ補完し、上書きしません。プロバイダーが既に設定している同名の変数（例: ANTHROPIC_BASE_URL）は元の値を保持するため、プロバイダー切り替えが壊れません。",
+      "codexIncludeAllowlistWarning": "Codex に shell_environment_policy.include_only の許可リストが設定されています。Codex は注入した変数をこのリストでフィルタするため、Codex 側では反映されない可能性があります。"
+    },
     "terminal": {
       "title": "優先ターミナル",
       "description": "ターミナルボタンをクリックした時に使用するターミナルアプリを選択",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -756,6 +756,26 @@
       "copy": "檔案複製",
       "symlinkHint": "軟連結節省磁碟空間並支援即時同步。注意：Windows 可能需要管理員權限或開啟開發者模式"
     },
+    "envInjection": {
+      "title": "環境變數注入",
+      "description": "把變數寫進各 CLI 自己的設定檔，不改系統環境、不依賴本機代理。",
+      "enable": "啟用環境變數注入",
+      "enableDescription": "關閉時 CCSwitchMulti 不會往任何 CLI 設定寫入變數。",
+      "targets": "作用範圍",
+      "targetsDescription": "依 CLI 個別開關，互不影響。",
+      "claude": "Claude Code",
+      "codex": "Codex",
+      "geminiUnsupported": "Gemini CLI 官方設定沒有行程層級的環境變數欄位，因此不支援注入。",
+      "variables": "變數",
+      "empty": "還沒有變數。新增並儲存後會寫入對應 CLI 的設定。",
+      "keyPlaceholder": "變數名稱",
+      "valuePlaceholder": "值",
+      "add": "新增變數",
+      "invalidKey": "變數名稱不能為空，且不能包含 =、換行或 NUL。",
+      "duplicateKey": "該變數名稱已存在。",
+      "mergeHint": "只補缺、不覆寫：供應商設定中既有的同名變數（如 ANTHROPIC_BASE_URL）會保留原值，避免打亂供應商切換。",
+      "codexIncludeAllowlistWarning": "偵測到 Codex 設定了 shell_environment_policy.include_only 白名單，官方會用它過濾掉注入的變數，Codex 側可能不會生效。"
+    },
     "terminal": {
       "title": "首選終端機",
       "description": "選擇點擊終端機按鈕時使用的終端機應用程式",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -764,6 +764,26 @@
       "copy": "文件复制",
       "symlinkHint": "软连接节省磁盘空间并支持实时同步。注意：Windows 可能需要管理员权限或开启开发者模式"
     },
+    "envInjection": {
+      "title": "环境变量注入",
+      "description": "把变量写进各 CLI 自己的配置文件，不改系统环境、不依赖本地代理。",
+      "enable": "启用环境变量注入",
+      "enableDescription": "关闭时 CCSwitchMulti 不会往任何 CLI 配置里写入变量。",
+      "targets": "生效范围",
+      "targetsDescription": "按 CLI 单独开关，互不影响。",
+      "claude": "Claude Code",
+      "codex": "Codex",
+      "geminiUnsupported": "Gemini CLI 官方配置没有进程级环境变量字段，因此不支持注入。",
+      "variables": "变量",
+      "empty": "还没有变量。添加后保存即可写入对应 CLI 的配置。",
+      "keyPlaceholder": "变量名",
+      "valuePlaceholder": "值",
+      "add": "添加变量",
+      "invalidKey": "变量名不能为空，且不能包含 =、换行或 NUL。",
+      "duplicateKey": "变量名已存在。",
+      "mergeHint": "只补缺、不覆盖：供应商配置里已有的同名变量（如 ANTHROPIC_BASE_URL）会保持原值，避免打乱供应商切换。",
+      "codexIncludeAllowlistWarning": "检测到 Codex 配置了 shell_environment_policy.include_only 白名单，官方会用它过滤掉注入的变量，Codex 侧可能不生效。"
+    },
     "terminal": {
       "title": "首选终端",
       "description": "选择点击终端按钮时使用的终端应用",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -4,6 +4,7 @@ import type {
   WebDavSyncSettings,
   S3SyncSettings,
   RemoteSnapshotInfo,
+  EnvInjectionConflicts,
 } from "@/types";
 import type { AppId } from "./types";
 
@@ -67,6 +68,21 @@ export const settingsApi = {
 
   async save(settings: Settings): Promise<boolean> {
     return await invoke("save_settings", { settings });
+  },
+
+  /**
+   * 检查环境变量注入是否存在已知的失效风险（只读）。
+   *
+   * 失败一律按「没有冲突」处理，调用方不应让提示信息阻塞 UI。
+   */
+  async inspectEnvInjectionConflicts(): Promise<EnvInjectionConflicts | null> {
+    try {
+      return await invoke<EnvInjectionConflicts>(
+        "inspect_env_injection_conflicts",
+      );
+    } catch {
+      return null;
+    }
   },
 
   /** 是否存在统一 Codex 会话历史的迁移备份（关闭弹窗据此显示"恢复备份"勾选） */

--- a/src/types.ts
+++ b/src/types.ts
@@ -683,6 +683,9 @@ export interface Settings {
   // ===== Codex 多设备额度协作设置 =====
   quotaCollaboration?: QuotaCollaborationSettings;
 
+  // ===== 环境变量自动注入 =====
+  envInjection?: EnvInjectionSettings;
+
   // ===== 备份策略设置 =====
   // Auto-backup interval in hours (0=disabled, default 24)
   backupIntervalHours?: number;
@@ -706,6 +709,33 @@ export interface Settings {
       migratedStateRows?: number;
     };
   };
+}
+
+/**
+ * 环境变量自动注入设置。
+ *
+ * 变量会写进各 CLI 自己的配置文件，因此**不走本地代理、直接运行官方 CLI**
+ * 时同样生效。合并语义是「只补缺、不覆盖」：provider `settingsConfig.env`
+ * 里已有的同名键不会被顶掉，避免打乱供应商路由。
+ */
+export interface EnvInjectionSettings {
+  /** 总开关，默认关闭。 */
+  enabled: boolean;
+  /** 按 CLI 的独立开关。未列出的 CLI 官方配置没有可写入的位置，因此不提供。 */
+  targets: {
+    /** 写入 `~/.claude/settings.json` 的 `env`（官方文档：无论如何启动 claude 都生效）。 */
+    claude: boolean;
+    /** 写入 `~/.codex/config.toml` 的 `[shell_environment_policy] set`（只作用于 Codex 派生的子进程）。 */
+    codex: boolean;
+  };
+  /** 要注入的键值对。 */
+  variables: Record<string, string>;
+}
+
+/** 当前 live 配置里已知会让注入失效的冲突，仅用于 UI 提示。 */
+export interface EnvInjectionConflicts {
+  /** Codex 配了 include 型 allowlist，官方会用它过滤掉 `set` 恢复出来的值。 */
+  codexIncludeAllowlist: boolean;
 }
 
 /** 多设备额度协作的本机配置，不包含任何 Codex 登录凭据。 */


### PR DESCRIPTION
# feat: 环境变量自动注入（总开关 + 按 CLI 独立开关）

Closes #84

## 背景

CCSM 目前能在 provider 级配置 `env`（Claude 的 `settings.json`、OpenClaw 的 env 节点等），
但**没有"全局、跨供应商"的环境变量能力**。典型场景：想让某个 CLI 跑在指定时区
（`TZ=Asia/Shanghai`）而不改系统时区，或者给 agent 派生的子进程统一注入
`HTTP_PROXY` / `NO_PROXY`，目前只能手工改各 CLI 的配置文件，且**每次切换供应商都会被冲掉**。

本 PR 把这件事做成一等公民，并且满足一条硬约束：

> **不启用 CCSM 本地代理、直接运行官方 `codex` / `claude` 命令时也必须生效。**

## 为什么只写 CLI 自己的配置文件

| 方案 | 问题 |
| --- | --- |
| shell rc 里 `export` | 全局污染所有进程，与"只影响这一个 CLI"的目标相悖 |
| PATH shim / 包装脚本 | 侵入性强，CLI 自更新后容易失效 |
| **写进 CLI 自己的配置文件** | CLI 每次启动都会读自己的配置，**与是否走本地代理完全无关**；无侵入、无全局副作用 |

三家 CLI 的官方能力边界（决定了本 PR 支持谁）：

| CLI | 写入位置 | 官方依据 | 作用域 |
| --- | --- | --- | --- |
| Claude Code | `~/.claude/settings.json` 的 `env` | 官方文档："Claude Code 在启动时直接从文件读取它们，因此无论如何启动 claude，它们都会生效" | 主进程 + 子进程 |
| Codex CLI | `~/.codex/config.toml` 的 `[shell_environment_policy] set` | 官方文档：控制"Codex 传给其所派生子进程的环境变量" | **仅子进程，不含 Codex 主进程** |
| Gemini CLI | — | 官方 `settings.json` 没有进程级 env 字段，`mcpServers.*.env` 的值仅支持 `$VAR` 展开 | **不支持** |

因此 UI 里只给 Claude / Codex 两个目标开关，并明确写出 Gemini 不支持的原因——
不做"开关能开但没效果"的假功能。

## 实现

### 数据模型（`settings.rs`）

```rust
pub struct EnvInjectionSettings {
    pub enabled: bool,                    // 总开关，默认 false
    pub targets: EnvInjectionTargets,     // { claude: bool, codex: bool }，均默认 true
    pub variables: BTreeMap<String,String>,
}
```

挂在 `AppSettings` 上（`#[serde(default)]`，老配置文件无需迁移）。用 `BTreeMap`
保证序列化顺序稳定，避免 Map 顺序抖动造成配置文件无意义 diff。

### 注入通道（`env_injection.rs`）

- **Claude**：合并进 `settings.json` 的 `env` 对象
- **Codex**：用 `toml_edit` 写入 `[shell_environment_policy] set`
- 关闭开关时反向摘除，**只删值完全匹配的条目**——用户手改过的值视为用户所有，不动

### 三个触发时机

1. **设置变更**：`update_settings()` 存盘后调用 `sync_to_live_configs()`（先释放设置
   RwLock 再同步，RwLock 不可重入，持锁回调会死锁）
2. **供应商切换**：Claude 的三个 live 写入点、Codex 的**所有** `config.toml` 落盘点都会
   补回注入结果。Codex 特意挂在**最底层**（`write_codex_live_config_atomic_locked` /
   `reconcile_codex_live_config_atomic_locked` / `write_codex_live_atomic_locked`），
   因为本地代理接管等路径会**整体重写** `config.toml`，只挂在上层会被抹掉
3. **冲突提示**：新增 `inspect_env_injection_conflicts` 命令，检测到 Codex 配了
   `include_only` allowlist 时在 UI 上提示（官方会用该 allowlist 过滤掉 `set` 恢复出来的值）

### 合并语义：**只补缺、不覆盖**

全局变量**不会**覆盖 provider `settings_config.env` 里已有的同名键。provider 的 env 存放
路由相关变量（`ANTHROPIC_BASE_URL`、`ANTHROPIC_API_KEY` 等），一旦允许覆盖，用户填一个
同名变量就会静默打乱供应商切换。这条语义让本功能在结构上无法破坏现有供应商切换。

另外，`sync_claude_live` 在把 live 配置读回、存进供应商记录前会先 `strip_from_claude_settings()`
摘掉注入的变量——注入是全局的、由设置单独管理，不能被固化进某一条供应商记录（否则会
污染备份与云同步）。

## 兼容性

- **默认关闭**，未启用时全部代码路径都是 no-op，不写任何文件、不改任何现有行为
- `AppSettings` 新增字段带 `#[serde(default)]`，老 `settings.json` 无需迁移
- Codex 注入失败时降级为"原样返回"并记 warn——增强功能不应该让原本正常的供应商切换失败

## 测试

`env_injection.rs` 新增 7 个单元测试，覆盖：

- 不覆盖 provider 已有的 `ANTHROPIC_BASE_URL`
- 只删值匹配的条目，用户改过的值保留
- 产出的 TOML 合法且保留原有内容
- `set` 被清空后连带清理空表
- `include_only` allowlist 检测
- 空变量集合不改动配置

已跑：`cargo test`、`cargo clippy`（本 PR 新增代码无告警）、`cargo fmt --check`、
`pnpm typecheck`、`pnpm format:check`、`vite build`。

> 注：本地 clippy 版本较新，仓库里有 17 处**既有**代码告警（集中在 `preset_catalog.rs`、
> `proxy/forwarder.rs`、`proxy/providers/codex.rs`），本 PR 未触碰也未新增。

## 已知限制

1. **Codex 只作用于其派生的子进程**，不改变 Codex 主进程自身的环境（官方行为，非本 PR 取舍）
2. **Gemini CLI 不支持**，UI 里已写明原因而非给一个无效开关
3. Codex 配了 `shell_environment_policy.include_only` 时注入可能被过滤，UI 会给出提示

## UI

设置 → 通用 → 底部新增「环境变量注入」：总开关 + Claude / Codex 两个目标开关 + 变量键值表。
zh / en / ja / zh-TW 四语文案已补齐，Codex 命中 `include_only` 冲突时面板内直接给黄色提示。

## 复查清单（供 review 时对照）

- 生产代码里 Claude live `settings.json` 的写入点共 3 处（`live.rs::write_live_snapshot`、
  `services/config.rs::sync_claude_live`、`services/proxy.rs::write_claude_live`），已全部挂上注入。
  `LiveSnapshot::restore` 只有测试代码调用（`#[cfg(test)]`），不需要挂。
- Codex 的所有 `config.toml` 落盘点已挂上注入，包括会整体重写文件的本地代理接管路径。
- 注入全程只在**即将写盘的文本**上操作，不读也不写供应商数据库记录。
