### PR TITLE
fix(probe): preserve OpenCode Go session identity in deep probes

### DIFF
--- a/src-tauri/src/protocol_compatibility/runner.rs
+++ b/src-tauri/src/protocol_compatibility/runner.rs
@@ -1057,6 +1057,28 @@ async fn send_case(
     continuation: Option<(&CapturedToolCall, &CapturedProbeExchange)>,
     options: CodexRequestOptions,
 ) -> Result<CapturedProbeExchange, ProbeCaptureError> {
+    let request = prepare_case_request(
+        candidate,
+        client,
+        transport,
+        case,
+        nonce,
+        continuation,
+        options,
+    )?;
+    capture_transport_probe(request, RESPONSE_TIMEOUT).await
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_case_request(
+    candidate: &ProbeCandidate,
+    client: &Client,
+    transport: TransportKind,
+    case: ProbeCase,
+    nonce: &str,
+    continuation: Option<(&CapturedToolCall, &CapturedProbeExchange)>,
+    options: CodexRequestOptions,
+) -> Result<reqwest::RequestBuilder, ProbeCaptureError> {
     let logical = match continuation {
         Some((tool_call, exchange)) => build_continuation_request(
             &candidate.upstream_model,
@@ -1067,14 +1089,119 @@ async fn send_case(
         ),
         None => build_logical_probe_request(case, &candidate.upstream_model, nonce),
     };
-    let prepared = candidate
+    let mut prepared = candidate
         .prepare_request_with_options(transport, logical, options)
         .map_err(|_| ProbeCaptureError::InvalidPayload)?;
-    let request = client
+    // This direct probe bypasses the runtime forwarder. Reuse its Go identity policy
+    // after provider overrides, with one stable identity per independent branch.
+    // The nonce is allocated once per candidate run, not once per HTTP request.
+    let branch = match transport {
+        TransportKind::OpenAiResponses => "responses",
+        TransportKind::OpenAiChat => "chat",
+    };
+    crate::proxy::apply_opencode_go_identity(
+        &mut prepared.headers,
+        &prepared.url,
+        &format!("ccsm-probe-{nonce}-{branch}"),
+        true,
+    );
+    Ok(client
         .post(prepared.url)
         .headers(prepared.headers)
-        .json(&prepared.body);
-    capture_transport_probe(request, RESPONSE_TIMEOUT).await
+        .json(&prepared.body))
+}
+
+#[cfg(test)]
+mod opencode_go_probe_tests {
+    use super::*;
+
+    fn request(
+        base_url: &str,
+        transport: TransportKind,
+        case: ProbeCase,
+        nonce: &str,
+    ) -> reqwest::Request {
+        let candidate = ProbeCandidate::new(
+            None::<String>,
+            None::<String>,
+            "deepseek-flash",
+            "deepseek-flash",
+            transport,
+            base_url,
+            "bearer",
+        )
+        .unwrap()
+        .with_bearer_token("fixture-secret")
+        .unwrap();
+        prepare_case_request(
+            &candidate,
+            &Client::new(),
+            transport,
+            case,
+            nonce,
+            None,
+            CodexRequestOptions::default(),
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+    }
+
+    #[test]
+    fn opencode_go_probe_requests_share_identity_within_each_branch() {
+        let url = "https://opencode.ai/zen/go/v1";
+        for transport in [TransportKind::OpenAiChat, TransportKind::OpenAiResponses] {
+            let baseline = request(url, transport, ProbeCase::BaselineJson, "run-a");
+            let identity = baseline.headers().get("x-opencode-session").unwrap();
+            for case in [
+                ProbeCase::BaselineSse,
+                ProbeCase::ForcedToolSse,
+                ProbeCase::ForcedToolRequiredSse,
+            ] {
+                let next = request(url, transport, case, "run-a");
+                assert_eq!(next.headers().get("x-opencode-session"), Some(identity));
+                assert_eq!(
+                    next.headers()["user-agent"],
+                    concat!("CCSwitchMulti/", env!("CARGO_PKG_VERSION"))
+                );
+            }
+            let new_run = request(url, transport, ProbeCase::BaselineJson, "run-b");
+            assert_ne!(new_run.headers().get("x-opencode-session"), Some(identity));
+        }
+        let chat = request(
+            url,
+            TransportKind::OpenAiChat,
+            ProbeCase::BaselineJson,
+            "run-a",
+        );
+        let responses = request(
+            url,
+            TransportKind::OpenAiResponses,
+            ProbeCase::BaselineJson,
+            "run-a",
+        );
+        assert_ne!(
+            chat.headers()["x-opencode-session"],
+            responses.headers()["x-opencode-session"]
+        );
+    }
+
+    #[test]
+    fn opencode_go_probe_identity_does_not_leak_to_other_endpoints() {
+        for url in [
+            "https://example.com/v1",
+            "https://opencode.ai/zen/v1",
+            "https://opencode.ai.example.com/zen/go/v1",
+        ] {
+            let request = request(
+                url,
+                TransportKind::OpenAiChat,
+                ProbeCase::BaselineJson,
+                "run-a",
+            );
+            assert!(!request.headers().contains_key("x-opencode-session"));
+        }
+    }
 }
 
 fn probe_request_options(

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -6320,7 +6320,7 @@ fn is_opencode_go_upstream_url(url: &str) -> bool {
 /// Normalize the identity required by OpenCode Go at the final outbound boundary.
 /// Preserve an explicit Go session header. If a protocol conversion removed it, derive it only
 /// from a stable client-provided session; the per-request fallback UUID is never sent upstream.
-fn apply_opencode_go_identity(
+pub(crate) fn apply_opencode_go_identity(
     headers: &mut http::HeaderMap,
     url: &str,
     session_id: &str,

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -15,6 +15,7 @@ pub mod error_mapper;
 pub mod external_openai_api;
 pub(crate) mod failover_switch;
 mod forwarder;
+pub(crate) use forwarder::apply_opencode_go_identity;
 pub mod gemini_url;
 pub mod handler_config;
 pub mod handler_context;


### PR DESCRIPTION
## Summary / 概述

Codex compatibility deep probes send requests directly through `send_case`, bypassing the runtime forwarder's OpenCode Go identity normalization. As a result, a probe without explicitly configured session headers can be rejected before its baseline succeeds, even though the runtime forwarding fix is already installed.

Reuse the existing Go identity policy immediately before building each probe HTTP request. Derive a stable session from the candidate-run nonce and transport branch, retaining it across stages, retries, and continuation; new runs and independent Chat/Responses branches get distinct identities. Existing explicit Go session headers retain the runtime policy's precedence. Other endpoints are unaffected.

Live verification on OpenCode Go with `deepseek-flash` reproduced HTTP 400 `MissingSessionID` without the session header and HTTP 200 with it. After installing this patch locally, the desktop deep probe completed with Verified 1 / Partial 0 / Failed 0, and its verified observations were persisted.

## Related Issue / 关联 Issue

Follow-up to cfd7c12585dc7735cbabc307cf69b9c7153c41d6, which added identity normalization to runtime forwarding. No separate issue.

## Screenshots / 截图

N/A — request header handling only; no UI change.

## Validation / 验证

- Added regressions that build requests through the same preparation function used by `send_case`: stable session headers across baseline/streaming/tool stages, separation between runs and transports, and no session-header injection for unrelated hosts or the Zen non-Go endpoint.
- `rustfmt --edition 2021 --check src-tauri/src/protocol_compatibility/runner.rs` and `git diff --check` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml opencode_go --lib`: **8 passed**.
- The compiled test binary with filter `protocol_compatibility::runner_tests`: **35 passed**.
- `pnpm typecheck`, `pnpm build:renderer`, and `cargo build --manifest-path src-tauri/Cargo.toml --bin cc-switch --features tauri/custom-protocol` passed on Windows after repairing the local MSVC installation.
- Installed the locally built executable and ran the desktop deep probe against OpenCode Go `deepseek-flash`: both Chat and Responses branches verified baseline, SSE, reasoning, tool calls, and continuation. Chat Completions remained selected. The Responses branch negotiated the existing MFJS tool-schema adaptation.
- Confirmed both verified branch observations in the saved SQLite database. No credentials or response bodies are included here. This verifies the desktop probe path; it is not a separate full Codex coding-session test.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes.
- [ ] `pnpm format:check` passes / Not run; targeted Rust formatting check passed.
- [ ] `cargo clippy` passes (if Rust code changed) / Not run; targeted tests and local application build passed.
- [x] Updated i18n files if user-facing text changed / N/A; no user-facing text changed.
