### PR TITLE
fix(codex): preserve reasoning declarations for saved routes

### DIFF
--- a/src/components/codex/CodexRouterWorkspacePage.test.ts
+++ b/src/components/codex/CodexRouterWorkspacePage.test.ts
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { providersApi } from "@/lib/api";
+import { codexSubagentV2Api } from "@/lib/api/codexSubagentV2";
 import {
   fetchCodexOauthModels,
   fetchModelsForConfig,
@@ -367,6 +368,89 @@ it("没有 MultiRouter 方案时打开工作台不会读取 null settingsConfig"
 });
 
 describe("Codex MultiRouter workspace route persistence helpers", () => {
+  it.each(["deepseek-flash", "deepseek-flash-opencode-go"])(
+    "preserves declared reasoning for saved route %s when another provider has the same model",
+    async (visibleModel) => {
+      const reasoning = {
+        schemaVersion: 2 as const,
+        supportStatus: "confirmed_supported" as const,
+        controlKind: "graded" as const,
+        supportedEfforts: ["low", "high", "max"],
+        defaultEffort: "max",
+        disableAllowed: false,
+        upstream: {
+          format: "string",
+          parameter: "reasoning_effort",
+          effortMap: { low: "low", high: "high", max: "max" },
+        },
+        source: "user",
+      };
+      const source: Provider = {
+        id: "opencode-go",
+        name: "OpenCode Go 原生",
+        settingsConfig: {
+          modelCatalog: { models: [{ model: "deepseek-flash", reasoning }] },
+        },
+      };
+      const duplicate: Provider = {
+        ...source,
+        id: "deepseek",
+        name: "DeepSeek",
+        settingsConfig: {
+          modelCatalog: { models: [{ model: "deepseek-flash" }] },
+        },
+      };
+      const plan: Provider = {
+        id: "codex-multirouter",
+        name: "Codex MultiRouter",
+        settingsConfig: {
+          codexRouting: {
+            schemaVersion: 2,
+            enabled: true,
+            subagentVersion: "v2",
+            routes: [
+              {
+                id: "go-route",
+                enabled: true,
+                targetProviderId: source.id,
+                modelSelection: { mode: "include", models: [visibleModel] },
+                ...(visibleModel !== "deepseek-flash"
+                  ? { aliases: { [visibleModel]: "deepseek-flash" } }
+                  : {}),
+              },
+            ],
+            subagentV2: { schemaVersion: 2, profiles: {} },
+          },
+        },
+      };
+      renderWorkspace(
+        React.createElement(CodexRouterWorkspacePage, {
+          providers: [duplicate, source, plan],
+          activeProviderId: plan.id,
+          isProxyRunning: true,
+          isCodexTakeoverActive: true,
+          initialProviderId: plan.id,
+          initialTab: "subagents",
+          onEditProvider: vi.fn(),
+          onDeletePlan: vi.fn(),
+          onCreateProvider: vi.fn(),
+        }),
+      );
+      await waitFor(() => {
+        expect(
+          codexSubagentV2Api.getReasoningCapabilities,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modelCatalog: expect.objectContaining({
+              models: expect.arrayContaining([
+                expect.objectContaining({ model: visibleModel, reasoning }),
+              ]),
+            }),
+          }),
+        );
+      });
+    },
+  );
   it("explains safe metadata refresh refusal without implying a network failure", () => {
     expect(
       workspaceErrorMessage("codex_provider_set_probe_required"),

--- a/src/components/codex/CodexRouterWorkspacePage.tsx
+++ b/src/components/codex/CodexRouterWorkspacePage.tsx
@@ -2103,6 +2103,24 @@ export function buildModelCatalogForRoutes(
     const targetCatalogModels = targetProvider
       ? readCodexModelCatalog(targetProvider).models
       : [];
+    // Saved routes use their persisted names, not the wizard's temporary
+    // collision aliases. Resolve only aliases explicitly saved on this route.
+    for (const [visible, upstream] of Object.entries(
+      route.aliases ?? route.upstream?.modelMap ?? {},
+    )) {
+      if (targetCatalogModels.some((entry) => entry.model === visible))
+        continue;
+      const source = targetCatalogModels.find(
+        (entry) => entry.model === upstream,
+      );
+      if (source) {
+        targetCatalogModels.push({
+          ...source,
+          model: visible,
+          upstreamModel: upstream,
+        });
+      }
+    }
     const routableCatalogModels =
       route.modelSelection?.mode === "all"
         ? targetCatalogModels.filter(
@@ -3133,8 +3151,8 @@ export function CodexRouterWorkspacePage({
     null;
   const selectedRouting = selectedPlan ? readCodexRouting(selectedPlan) : null;
   const selectedProjectedCatalog = useMemo(
-    () => projectCodexModelCatalog(selectedPlan, routableProvidersById),
-    [selectedPlan, routableProvidersById],
+    () => projectCodexModelCatalog(selectedPlan, providersById),
+    [selectedPlan, providersById],
   );
   const selectedPlanRouteEntries = selectedPlan
     ? routeEntries.filter(({ provider }) => provider.id === selectedPlan.id)


### PR DESCRIPTION
## Summary / 概述

Fix the false “推理能力未配置” error when saving Sub-Agent V2 configuration after reasoning capabilities have already been declared on the routed Provider.

When two Providers expose `deepseek-flash`, the workspace's wizard collision handling gives one source a temporary alias. A saved route can still reference the original name, so catalog projection falls back to a model-only entry and drops its reasoning declaration. The backend then reports unknown reasoning support and blocks saving.

Project saved routes from the actual Provider records, and copy capability metadata for aliases explicitly persisted on the route. Keep the existing unknown-capability save guard intact.

Regression coverage reproduces the missing declaration before the fix and verifies that the original name and an explicit alias both retain the routed Provider's `low / high / max` declaration, even when another Provider exposes the same model. Workspace tests: 81 passed; Sub-Agent editor tests: 127 passed.

## Related Issue / 关联 Issue

N/A — reported through local troubleshooting.

## Screenshots / 截图

N/A — this changes catalog resolution, with no visual layout changes. The regression tests check the capability data passed to the backend.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查 — equivalent `node node_modules/typescript/bin/tsc --noEmit` passed.
- [ ] `pnpm format:check` passes / 通过代码格式检查 — both changed files pass Prettier; repository-wide formatting was not run.
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码） — N/A, no Rust changes.
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — N/A, no user-facing text changes.