### PR TITLE
fix(codex): prevent timezone injection from bypassing Windows package activation

### DIFF
--- a/src-tauri/src/codex_desktop.rs
+++ b/src-tauri/src/codex_desktop.rs
@@ -10,6 +10,10 @@ use sha2::{Digest, Sha256};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 
+#[cfg(target_os = "windows")]
+#[path = "codex_windows_launch.rs"]
+pub(crate) mod windows_launch;
+
 pub(crate) const DEFAULT_CODEX_DEBUG_PORT: u16 = 9229;
 pub(crate) const CDP_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
 const CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(4);
@@ -1776,6 +1780,10 @@ pub(crate) fn launch_codex_with_debug_port(
             );
         }
     }
+    #[cfg(target_os = "windows")]
+    if let Some(app_id) = windows_launch::resolve_app_id(executable)? {
+        return launch_windows_app(&app_id, debug_port);
+    }
     let mut command = Command::new(executable);
     append_codex_debug_args(&mut command, debug_port);
     apply_codex_launch_timezone(&mut command, launch_timezone.as_deref());
@@ -1802,13 +1810,25 @@ fn apply_codex_launch_timezone(command: &mut Command, timezone: Option<&str>) {
     }
 }
 
+#[cfg(target_os = "windows")]
+pub(crate) fn launch_windows_app(app_id: &str, debug_port: u16) -> Result<(), String> {
+    windows_launch::activate(app_id, debug_port)?;
+    // The activation broker does not inherit our per-child environment. Renderer
+    // timezone emulation is applied separately by install_script over CDP.
+    crate::codex_egress_timezone::mark_codex_timezone_not_inherited();
+    Ok(())
+}
+
+fn codex_debug_args(debug_port: u16) -> [String; 2] {
+    [
+        format!("--remote-debugging-port={debug_port}"),
+        format!("--remote-allow-origins=http://127.0.0.1:{debug_port}"),
+    ]
+}
+
 /// 为 Desktop 启动命令追加 Chromium remote-debugging 参数。
 fn append_codex_debug_args(command: &mut Command, debug_port: u16) {
-    command
-        .arg(format!("--remote-debugging-port={debug_port}"))
-        .arg(format!(
-            "--remote-allow-origins=http://127.0.0.1:{debug_port}"
-        ));
+    command.args(codex_debug_args(debug_port));
 }
 
 /// Windows 下查找 Codex App 主进程的脚本。
@@ -2664,6 +2684,21 @@ fn version_tuple_from_package_name(name: &str) -> Vec<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn desktop_launch_transports_share_the_requested_debug_port() {
+        let mut command = Command::new("codex-desktop-placeholder");
+        append_codex_debug_args(&mut command, 9231);
+        let arguments: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy())
+            .collect();
+        assert_eq!(arguments, codex_debug_args(9231));
+        assert_eq!(
+            codex_debug_args(9231).join(" "),
+            "--remote-debugging-port=9231 --remote-allow-origins=http://127.0.0.1:9231"
+        );
+    }
 
     /// 返回当前测试平台的 Desktop 主程序文件名。
     fn desktop_test_executable_name() -> &'static str {

--- a/src-tauri/src/codex_egress_timezone.rs
+++ b/src-tauri/src/codex_egress_timezone.rs
@@ -57,6 +57,7 @@ pub enum CodexEgressMonitorState {
     Checking,
     Ready,
     RestartRequired,
+    RendererOnly,
     Error,
 }
 
@@ -67,6 +68,7 @@ pub(crate) struct CodexEgressMonitorRuntime {
     pub last_trigger: Option<String>,
     pub last_error: Option<String>,
     pub restart_required: bool,
+    pub process_timezone_unavailable: bool,
     pub consecutive_failures: u32,
 }
 
@@ -98,11 +100,16 @@ pub(crate) fn monitor_status_from_parts(
     runtime: &CodexEgressMonitorRuntime,
     _now: i64,
 ) -> CodexEgressMonitorStatus {
-    let state = if settings.mode != CodexEgressTimezoneMode::Auto {
+    let process_timezone_unavailable =
+        runtime.process_timezone_unavailable && settings.mode != CodexEgressTimezoneMode::Off;
+    let restart_required = runtime.restart_required && !process_timezone_unavailable;
+    let state = if process_timezone_unavailable {
+        CodexEgressMonitorState::RendererOnly
+    } else if settings.mode != CodexEgressTimezoneMode::Auto {
         CodexEgressMonitorState::Disabled
     } else if runtime.running {
         CodexEgressMonitorState::Checking
-    } else if runtime.restart_required {
+    } else if restart_required {
         CodexEgressMonitorState::RestartRequired
     } else if runtime.last_error.is_some() {
         CodexEgressMonitorState::Error
@@ -133,7 +140,7 @@ pub(crate) fn monitor_status_from_parts(
                 .map(|at| at.saturating_add(i64::from(interval) * 60))
         },
         monitor_interval_minutes: interval,
-        restart_required: runtime.restart_required,
+        restart_required,
     }
 }
 
@@ -816,6 +823,22 @@ pub(crate) fn notify_proxy_failure(app_type: &str, error: &ProxyError) {
 
 pub(crate) fn mark_codex_timezone_applied() {
     let applied_timezone = resolve_launch_timezone(&crate::settings::get_settings());
+    record_codex_launch_timezone(applied_timezone, false);
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn mark_codex_timezone_not_inherited() {
+    let configured = resolve_launch_timezone(&crate::settings::get_settings());
+    if configured.is_some() {
+        log::warn!("Codex MSIX activation cannot inherit TZ; process timezone remains unapplied. Renderer timezone emulation will be attempted over CDP.");
+    }
+    record_codex_launch_timezone(None, true);
+}
+
+fn record_codex_launch_timezone(
+    applied_timezone: Option<String>,
+    process_timezone_unavailable: bool,
+) {
     if let Err(error) = crate::settings::mutate_codex_egress_timezone(|settings| {
         settings.last_applied_timezone = applied_timezone;
         settings.last_applied_at = Some(Utc::now().timestamp());
@@ -826,6 +849,7 @@ pub(crate) fn mark_codex_timezone_applied() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     runtime.restart_required = false;
+    runtime.process_timezone_unavailable = process_timezone_unavailable;
     drop(runtime);
     emit_monitor_status(None);
 }
@@ -836,16 +860,21 @@ pub(crate) fn start_automatic_monitor(app_handle: AppHandle) {
         return;
     }
     let settings = crate::settings::get_settings().codex_egress_timezone;
-    if settings.mode == CodexEgressTimezoneMode::Auto
-        && settings.detected_timezone.is_some()
-        && settings.detected_timezone != settings.last_applied_timezone
-        && crate::codex_desktop::is_codex_desktop_running()
-    {
-        monitor_runtime()
+    let running = crate::codex_desktop::detect_running_codex_main_process();
+    #[cfg(target_os = "windows")]
+    let packaged = running
+        .as_deref()
+        .is_some_and(crate::codex_desktop::windows_launch::is_packaged_codex);
+    #[cfg(not(target_os = "windows"))]
+    let packaged = false;
+    initialize_monitor_launch_state(
+        &mut monitor_runtime()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .restart_required = true;
-    }
+            .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        &settings,
+        running.is_some(),
+        packaged,
+    );
     tauri::async_runtime::spawn(async move {
         let mut last_tick = Instant::now();
         loop {
@@ -862,6 +891,20 @@ pub(crate) fn start_automatic_monitor(app_handle: AppHandle) {
             }
         }
     });
+}
+
+pub(crate) fn initialize_monitor_launch_state(
+    runtime: &mut CodexEgressMonitorRuntime,
+    settings: &CodexEgressTimezoneSettings,
+    codex_running: bool,
+    packaged: bool,
+) {
+    runtime.process_timezone_unavailable = codex_running && packaged;
+    runtime.restart_required = !runtime.process_timezone_unavailable
+        && codex_running
+        && settings.mode == CodexEgressTimezoneMode::Auto
+        && settings.detected_timezone.is_some()
+        && settings.detected_timezone != settings.last_applied_timezone;
 }
 
 #[tauri::command]

--- a/src-tauri/src/codex_egress_timezone_tests.rs
+++ b/src-tauri/src/codex_egress_timezone_tests.rs
@@ -368,6 +368,58 @@ fn monitor_status_exposes_failure_backoff_as_the_next_check() {
     assert_eq!(status.state, CodexEgressMonitorState::Error);
     assert_eq!(status.next_check_at, Some(2_180));
 }
+
+#[test]
+fn package_activation_reports_renderer_only_without_a_refresh_loop() {
+    let runtime = CodexEgressMonitorRuntime {
+        process_timezone_unavailable: true,
+        restart_required: true,
+        ..CodexEgressMonitorRuntime::default()
+    };
+    for mode in [
+        CodexEgressTimezoneMode::Auto,
+        CodexEgressTimezoneMode::Manual,
+    ] {
+        let settings = CodexEgressTimezoneSettings {
+            mode,
+            ..CodexEgressTimezoneSettings::default()
+        };
+        let status = monitor_status_from_parts(&settings, &runtime, 2_010);
+        assert_eq!(status.state, CodexEgressMonitorState::RendererOnly);
+        assert!(!status.restart_required);
+    }
+    let status =
+        monitor_status_from_parts(&CodexEgressTimezoneSettings::default(), &runtime, 2_010);
+    assert_eq!(status.state, CodexEgressMonitorState::Disabled);
+}
+
+#[test]
+fn restarting_ccsm_preserves_the_running_package_timezone_limitation() {
+    let settings = CodexEgressTimezoneSettings {
+        mode: CodexEgressTimezoneMode::Auto,
+        detected_timezone: Some("Asia/Taipei".into()),
+        ..CodexEgressTimezoneSettings::default()
+    };
+    let mut runtime = CodexEgressMonitorRuntime::default();
+    super::codex_egress_timezone::initialize_monitor_launch_state(
+        &mut runtime,
+        &settings,
+        true,
+        true,
+    );
+    assert_eq!(
+        monitor_status_from_parts(&settings, &runtime, 0).state,
+        CodexEgressMonitorState::RendererOnly
+    );
+    assert!(!runtime.restart_required);
+    super::codex_egress_timezone::initialize_monitor_launch_state(
+        &mut runtime,
+        &settings,
+        true,
+        false,
+    );
+    assert!(runtime.restart_required);
+}
 #[tokio::test]
 #[ignore = "Explicit network diagnostic; never run as a regular test gate"]
 async fn live_trace_transport_diagnostic() {

--- a/src-tauri/src/codex_runtime_refresh.rs
+++ b/src-tauri/src/codex_runtime_refresh.rs
@@ -851,31 +851,10 @@ async fn query_refresh_targets() -> Result<CodexRuntimeRefreshTargets, String> {
     Ok(classify_refresh_targets(&processes))
 }
 
-#[cfg(target_os = "windows")]
-fn resolve_windows_codex_aumid() -> Option<String> {
-    let output = powershell_utf8_output(
-        r#"
-[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
-Get-StartApps |
-  Where-Object { $_.AppID -match '^OpenAI\.Codex(?:\.Preview)?_.*!App$' } |
-  Select-Object -First 1 -ExpandProperty AppID
-"#,
-    )
-    .ok()?;
-    let aumid = output.lines().next()?.trim();
-    (!aumid.is_empty()).then(|| aumid.to_string())
-}
-
 fn select_launch_target(
     aumid: Option<String>,
     executable: Option<PathBuf>,
-    timezone_injection_enabled: bool,
 ) -> Option<CodexRuntimeLaunchTarget> {
-    if timezone_injection_enabled {
-        if let Some(executable) = executable.clone() {
-            return Some(CodexRuntimeLaunchTarget::DesktopExecutable(executable));
-        }
-    }
     #[cfg(target_os = "windows")]
     if let Some(aumid) = aumid {
         return Some(CodexRuntimeLaunchTarget::WindowsAumid(aumid));
@@ -885,16 +864,16 @@ fn select_launch_target(
     executable.map(CodexRuntimeLaunchTarget::DesktopExecutable)
 }
 
-fn resolve_launch_target() -> Option<CodexRuntimeLaunchTarget> {
+fn resolve_launch_target() -> Result<Option<CodexRuntimeLaunchTarget>, String> {
     let executable = crate::codex_desktop::resolve_codex_executable();
-    let timezone_injection_enabled =
-        crate::codex_egress_timezone::resolve_launch_timezone(&crate::settings::get_settings())
-            .is_some();
     #[cfg(target_os = "windows")]
-    let aumid = resolve_windows_codex_aumid();
+    let aumid = match executable.as_deref() {
+        Some(path) => crate::codex_desktop::windows_launch::resolve_app_id(path)?,
+        None => None,
+    };
     #[cfg(not(target_os = "windows"))]
     let aumid = None;
-    select_launch_target(aumid, executable, timezone_injection_enabled)
+    Ok(select_launch_target(aumid, executable))
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -915,7 +894,7 @@ async fn build_preflight() -> Result<CodexRuntimeRefreshPreflight, String> {
 #[cfg(target_os = "windows")]
 async fn build_preflight() -> Result<CodexRuntimeRefreshPreflight, String> {
     let targets = query_refresh_targets().await?;
-    let launch_target = resolve_launch_target();
+    let launch_target = resolve_launch_target()?;
     let paginated_history =
         tokio::task::spawn_blocking(paginated_history::inspect_paginated_history_repair)
             .await
@@ -1061,41 +1040,13 @@ fn force_terminate_process(_pid: u32) -> Result<(), String> {
     Err("codex_runtime_refresh_windows_only".to_string())
 }
 
-#[cfg(target_os = "windows")]
-fn launch_windows_aumid(aumid: &str) -> Result<(), String> {
-    use windows::core::HSTRING;
-    use windows::Win32::System::Com::{
-        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_LOCAL_SERVER,
-        COINIT_APARTMENTTHREADED,
-    };
-    use windows::Win32::UI::Shell::{
-        ApplicationActivationManager, IApplicationActivationManager, AO_NONE,
-    };
-
-    let initialized = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED).is_ok() };
-    let result = (|| -> Result<(), String> {
-        let manager: IApplicationActivationManager =
-            unsafe { CoCreateInstance(&ApplicationActivationManager, None, CLSCTX_LOCAL_SERVER) }
-                .map_err(|error| format!("codex_aumid_activation_manager_failed: {error}"))?;
-        let arguments = HSTRING::from(format!(
-            "--remote-debugging-port={} --remote-allow-origins=http://127.0.0.1:{}",
-            crate::codex_desktop::DEFAULT_CODEX_DEBUG_PORT,
-            crate::codex_desktop::DEFAULT_CODEX_DEBUG_PORT
-        ));
-        unsafe { manager.ActivateApplication(&HSTRING::from(aumid), &arguments, AO_NONE) }
-            .map(|_| ())
-            .map_err(|error| format!("codex_aumid_activation_failed: {error}"))
-    })();
-    if initialized {
-        unsafe { CoUninitialize() };
-    }
-    result
-}
-
 fn launch_codex_target(target: &CodexRuntimeLaunchTarget) -> Result<(), String> {
     match target {
         #[cfg(target_os = "windows")]
-        CodexRuntimeLaunchTarget::WindowsAumid(aumid) => launch_windows_aumid(aumid),
+        CodexRuntimeLaunchTarget::WindowsAumid(aumid) => crate::codex_desktop::launch_windows_app(
+            aumid,
+            crate::codex_desktop::DEFAULT_CODEX_DEBUG_PORT,
+        ),
         CodexRuntimeLaunchTarget::DesktopExecutable(path) => {
             crate::codex_desktop::launch_codex_with_debug_port(
                 path,
@@ -1397,7 +1348,7 @@ pub async fn refresh_codex_runtime_state(
     let _refresh_guard = CODEX_RUNTIME_REFRESH_LOCK
         .try_lock()
         .map_err(|_| "codex_runtime_refresh_already_running".to_string())?;
-    let launch_target = resolve_launch_target()
+    let launch_target = resolve_launch_target()?
         .ok_or_else(|| "codex_desktop_launch_target_not_found".to_string())?;
     let progress = RuntimeRefreshProgressEmitter::new(app);
     let mut operations = SystemCodexRuntimeRefreshOperations {
@@ -1437,19 +1388,20 @@ mod tests {
         }));
     }
 
+    #[cfg(target_os = "windows")]
     #[test]
-    fn timezone_injection_prefers_executable_over_aumid_launch() {
+    fn registered_package_uses_activation_independently_of_timezone_settings() {
         let executable = PathBuf::from(r"C:\Program Files\WindowsApps\OpenAI.Codex\ChatGPT.exe");
-        let target = select_launch_target(
-            Some("OpenAI.Codex_123!App".to_string()),
-            Some(executable.clone()),
-            true,
-        );
-
+        let aumid = "OpenAI.Codex_publisher!UnifiedApp".to_string();
         assert_eq!(
-            target,
+            select_launch_target(Some(aumid.clone()), Some(executable.clone())),
+            Some(CodexRuntimeLaunchTarget::WindowsAumid(aumid))
+        );
+        assert_eq!(
+            select_launch_target(None, Some(executable.clone())),
             Some(CodexRuntimeLaunchTarget::DesktopExecutable(executable))
         );
+        assert_eq!(select_launch_target(None, None), None);
     }
     use std::collections::VecDeque;
 

--- a/src-tauri/src/codex_windows_launch.rs
+++ b/src-tauri/src/codex_windows_launch.rs
@@ -1,0 +1,151 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct RegisteredApplication {
+    executable: String,
+    app_id: String,
+}
+
+fn normalized_path(path: &str) -> String {
+    path.replace('/', "\\")
+        .trim_start_matches(r"\\?\")
+        .to_lowercase()
+}
+
+fn matching_app_id(applications: &[RegisteredApplication], executable: &Path) -> Option<String> {
+    let executable = normalized_path(&executable.to_string_lossy());
+    applications
+        .iter()
+        .find(|app| normalized_path(&app.executable) == executable)
+        .map(|app| app.app_id.clone())
+}
+
+pub(crate) fn is_packaged_codex(executable: &Path) -> bool {
+    normalized_path(&executable.to_string_lossy())
+        .split('\\')
+        .any(|part| part.starts_with("openai.codex_") || part.starts_with("openai.codex.preview_"))
+}
+
+pub(crate) fn resolve_app_id(executable: &Path) -> Result<Option<String>, String> {
+    if !is_packaged_codex(executable) {
+        return Ok(None);
+    }
+    // Match the registered manifest entry, not the first Start-menu shortcut:
+    // stable and Preview can coexist, and Application Id is not always "App".
+    let script = r#"
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+$items = @(Get-AppxPackage -Name 'OpenAI.Codex*' |
+  Where-Object { $_.Name -eq 'OpenAI.Codex' -or $_.Name -eq 'OpenAI.Codex.Preview' } |
+  ForEach-Object {
+    $package = $_
+    $manifest = Get-AppxPackageManifest -Package $package.PackageFullName
+    foreach ($app in $manifest.Package.Applications.Application) {
+      if ($app.Executable -and $app.Id) {
+        [PSCustomObject]@{
+          Executable = Join-Path $package.InstallLocation $app.Executable
+          AppId = $package.PackageFamilyName + '!' + $app.Id
+        }
+      }
+    }
+  })
+ConvertTo-Json -InputObject $items -Compress
+"#;
+    let value = super::powershell_json_value(script)
+        .ok_or_else(|| "codex_package_registration_query_failed".to_string())?;
+    let applications: Vec<RegisteredApplication> = serde_json::from_value(value)
+        .map_err(|error| format!("codex_package_registration_invalid: {error}"))?;
+    matching_app_id(&applications, executable)
+        .map(Some)
+        .ok_or_else(|| {
+            format!(
+                "codex_package_application_not_registered: {}",
+                executable.display()
+            )
+        })
+}
+
+pub(crate) fn activate(app_id: &str, debug_port: u16) -> Result<(), String> {
+    use windows::core::HSTRING;
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_LOCAL_SERVER,
+        COINIT_APARTMENTTHREADED,
+    };
+    use windows::Win32::UI::Shell::{
+        ApplicationActivationManager, IApplicationActivationManager, AO_NONE,
+    };
+
+    let initialization = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    // A Tauri worker may already be in the MTA; it still has a valid COM apartment.
+    const RPC_E_CHANGED_MODE: windows::core::HRESULT =
+        windows::core::HRESULT(0x80010106_u32 as i32);
+    if initialization.is_err() && initialization != RPC_E_CHANGED_MODE {
+        return Err(format!(
+            "codex_aumid_com_initialization_failed: {initialization}"
+        ));
+    }
+    let result = (|| -> Result<(), String> {
+        let manager: IApplicationActivationManager =
+            unsafe { CoCreateInstance(&ApplicationActivationManager, None, CLSCTX_LOCAL_SERVER) }
+                .map_err(|error| format!("codex_aumid_activation_manager_failed: {error}"))?;
+        let arguments = HSTRING::from(super::codex_debug_args(debug_port).join(" "));
+        unsafe { manager.ActivateApplication(&HSTRING::from(app_id), &arguments, AO_NONE) }
+            .map(|_| ())
+            .map_err(|error| format!("codex_aumid_activation_failed ({app_id}): {error}"))
+    })();
+    if initialization.is_ok() {
+        unsafe { CoUninitialize() };
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activation_matches_the_selected_package_and_manifest_application() {
+        let applications = vec![
+            RegisteredApplication {
+                executable: r"C:\Program Files\WindowsApps\OpenAI.Codex.Preview_2_x64__publisher\app\ChatGPT.exe".into(),
+                app_id: "OpenAI.Codex.Preview_publisher!App".into(),
+            },
+            RegisteredApplication {
+                executable: r"C:\Program Files\WindowsApps\OpenAI.Codex_1_x64__publisher\app\ChatGPT.exe".into(),
+                app_id: "OpenAI.Codex_publisher!UnifiedApp".into(),
+            },
+        ];
+        let selected = Path::new(
+            r"\\?\c:\program files\windowsapps\OpenAI.Codex_1_x64__publisher\app\ChatGPT.exe",
+        );
+        assert_eq!(
+            matching_app_id(&applications, selected).as_deref(),
+            Some("OpenAI.Codex_publisher!UnifiedApp")
+        );
+        assert!(matching_app_id(&applications, Path::new(r"C:\Other\ChatGPT.exe")).is_none());
+        assert_eq!(
+            matching_app_id(&applications, Path::new(&applications[0].executable)).as_deref(),
+            Some("OpenAI.Codex.Preview_publisher!App")
+        );
+    }
+
+    #[test]
+    fn standalone_installations_do_not_require_package_registration() {
+        assert_eq!(
+            resolve_app_id(Path::new(r"C:\Users\Test\Apps\Codex.exe")),
+            Ok(None)
+        );
+        assert!(!is_packaged_codex(Path::new(
+            r"C:\OpenAI.Codex.Tools\Codex.exe"
+        )));
+        assert!(is_packaged_codex(Path::new(
+            r"D:/WindowsApps/OpenAI.Codex_1_x64__publisher/app/ChatGPT.exe"
+        )));
+        assert!(is_packaged_codex(Path::new(
+            r"C:\WindowsApps\OpenAI.Codex.Preview_1_x64__publisher\app\Codex.exe"
+        )));
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -426,7 +426,8 @@ pub enum CodexEgressTimezoneMode {
 
 /// Codex Desktop 进程级出口时区设置。
 ///
-/// 仅在 CCSwitchMulti 启动 Codex 时通过子进程 `TZ` 环境变量生效，不会修改
+/// 直接启动时通过子进程 `TZ` 环境变量生效；MSIX 包激活无法继承该变量，
+/// 仅通过 CDP 尝试覆盖 renderer 时区，不标记进程时区已应用。不会修改
 /// Windows 系统时区。`auto` 使用后台监测到的最新 IANA 时区；监测失败不会
 /// 阻塞 Codex 请求或启动。
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/components/codex/CodexEgressTimezoneStatusCard.test.tsx
+++ b/src/components/codex/CodexEgressTimezoneStatusCard.test.tsx
@@ -12,6 +12,20 @@ vi.mock("@/lib/api/codexEgressTimezone", () => ({
 }));
 
 describe("CodexEgressTimezoneStatusCard", () => {
+  it("explains package activation without offering an ineffective refresh", async () => {
+    vi.mocked(codexEgressTimezoneApi.monitorStatus).mockResolvedValue({
+      state: "renderer_only",
+      monitorIntervalMinutes: 15,
+      restartRequired: false,
+    });
+    render(<CodexEgressTimezoneStatusCard onOpenCodexStatus={vi.fn()} />);
+    expect(await screen.findByText("仅支持页面时区同步")).toBeInTheDocument();
+    expect(screen.getByText(/重复刷新无法解除此限制/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "打开安全刷新" }),
+    ).not.toBeInTheDocument();
+  });
+
   beforeEach(() => {
     vi.mocked(codexEgressTimezoneApi.monitorStatus).mockReset();
     vi.mocked(codexEgressTimezoneApi.triggerAutomaticProbe).mockReset();

--- a/src/components/codex/CodexEgressTimezoneStatusCard.tsx
+++ b/src/components/codex/CodexEgressTimezoneStatusCard.tsx
@@ -25,6 +25,8 @@ function stateLabel(status: CodexEgressMonitorStatus) {
       return "监测正常";
     case "restart_required":
       return "出口已变化，需要刷新 Codex";
+    case "renderer_only":
+      return "仅支持页面时区同步";
     case "error":
       return "自动检测失败";
   }
@@ -127,6 +129,12 @@ export function CodexEgressTimezoneStatusCard({
             <p className="text-xs font-medium text-amber-800 dark:text-amber-200">
               新结果已经保存，但运行中的 app-server 仍使用旧 TZ。CCSM
               不会强制结束任务，请在没有运行任务时使用 Codex 状态页的安全刷新。
+            </p>
+          )}
+          {status?.state === "renderer_only" && (
+            <p className="text-xs font-medium text-amber-800 dark:text-amber-200">
+              Windows 应用包启动无法传入进程时区，只会尝试同步页面时区；
+              app-server 时区未覆盖，重复刷新无法解除此限制。
             </p>
           )}
           {(requestError || status?.lastError) && (

--- a/src/lib/api/codexEgressTimezone.ts
+++ b/src/lib/api/codexEgressTimezone.ts
@@ -38,6 +38,7 @@ export type CodexEgressMonitorState =
   | "checking"
   | "ready"
   | "restart_required"
+  | "renderer_only"
   | "error";
 
 export interface CodexEgressMonitorStatus {


### PR DESCRIPTION
## 问题与已确认原因

CCSM 3.20.2-9 在 Windows 上开启 Codex 出口时区自动模式、且已有有效检测时区时，“刷新 Codex 状态”可能关闭 Codex 后无法重新打开，报 `拒绝访问 (os error 5)`。

触发点是刷新流程的启动目标选择：`select_launch_target` 为传入进程级 `TZ`，在时区注入有效且 EXE 存在时优先选择 `DesktopExecutable`，绕过已经存在的 `WindowsAumid` 激活入口。关闭时区时则优先使用应用包激活。因此，同为 MSIX、同一 CCSM 版本，不同设置会走不同启动分支。

[基线启动目标选择代码](https://github.com/BigStrongSun/ccswitchmulti/blob/ab1b877de1324e8fb699214a2755168df9acdf08/src-tauri/src/codex_runtime_refresh.rs#L869-L897)

## 两台机器对比与实际验证

| 项目 | 刷新失败机器 | 刷新正常机器 |
| --- | --- | --- |
| CCSM | 3.20.2-9 | 3.20.2-9 |
| Codex MSIX 包版本 | 26.901.6511.0 | 26.908.4834.0 |
| 出口时区模式 | auto | off |
| 已保存检测时区 | America/Los_Angeles | America/Los_Angeles |
| Windows | 25H2 / 26200.9168 | 25H2 / 26200.9445 |

- 两台包目录和主 EXE 的安全描述符分别逐字一致：普通用户读取权限不包含执行权限；执行授权包含应用身份条件。没有证据支持“故障机器文件权限异常”。
- 正常机器的只读 `FILE_EXECUTE` 权限检查也返回 Win32 错误 5；普通路径与 `\\?\` 路径结果相同。此检查不创建进程。
- 故障机器在正常 Windows 用户账户下冷启动实测：直接创建包内 EXE 进程返回错误 5；相同调试参数通过 `IApplicationActivationManager::ActivateApplication` 启动成功，CDP `/json/version` 可用。
- 随后在故障机器关闭出口时区，用户确认同一刷新操作已恢复正常；读回配置确认 `mode=off`。无需更换 Codex 安装形式、重装或迁移历史数据。
- 两台 Codex/Windows 版本不同，但故障机器仅关闭时区即恢复，结合对应分支代码，确认本次刷新故障由时区功能选择直接 EXE 启动触发。没有在正常机器开启时区制造反向故障。

关闭出口时区是本次刷新故障已验证的临时解决办法；不能据此保证所有启动入口恢复，因为模型兼容注入和随 CCSM 启动等入口在基线中仍直接创建 EXE 进程。

## 修复

已注册 MSIX 包统一使用 `IApplicationActivationManager::ActivateApplication`，时区设置不再将刷新启动切回直接 EXE。模型兼容注入和随 CCSM 启动的入口也复用包激活，保留请求的 CDP 端口和 origin 参数。

通过当前用户的包注册和 manifest 将选定 EXE 精确映射为 AUMID，兼容 Stable/Preview 共存、非 `App` Application ID、扩展长度路径和大小写差异。独立安装版继续直接启动；包注册查询错误在刷新关闭进程前返回。

## 时区行为与限制

应用包激活无法继承 CCSM 设置的子进程 `TZ`，因此不把进程时区标记为已应用。保留现有 CDP renderer 时区覆盖，并展示“仅支持页面时区同步”；app-server 进程时区不保证覆盖。此状态不会引导用户反复刷新，CCSM 重启后会从运行中的包路径重建状态。

## 代码验证

- Windows GNU 隔离测试工程直接包含新增启动模块，并从修改后的源文件提取目标选择、参数和时区状态函数/测试：7 项通过，包含 Windows COM 绑定编译；不是完整 Tauri 构建。
- `CodexEgressTimezoneStatusCard.test.tsx`：3 项通过，使用原配置的程序化 Vitest 入口。
- `tsc --noEmit`、`cargo fmt --check`、修改的 TS/TSX 文件 Prettier 检查、`git diff --check` 通过。
- 已核对 Frontend CI 通过；macOS/Linux 后端在未修改的 `proxy/handlers.rs` 被基线已有的 `clippy::too_many_arguments` 阻塞，详见已有 CI 核对评论。完整 CI 状态以 Checks 为准。
- 上述用户验证针对原安装版的故障、包激活及关闭时区后的恢复；修复版 CCSM 二进制的整条刷新、模型兼容层和历史查询端到端验证仍未完成。
